### PR TITLE
Tolerance option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 0.1.4 (unreleased)
 ==================
 
+- Add `doctest-plus-atol` and `doctest-plus-rtol` options for setting the
+  numerical tolerance. [#21]
+
 0.1.3 (2018-04-20)
 ==================
 

--- a/pytest_doctestplus/output_checker.py
+++ b/pytest_doctestplus/output_checker.py
@@ -118,7 +118,8 @@ class OutputChecker(doctest.OutputChecker):
                 else:
                     nw_.append(nw)
 
-                if not np.allclose(float(ng), float(nw), equal_nan=True):
+                if not np.allclose(float(ng), float(nw), rtol=self.rtol,
+                                   atol=self.atol, equal_nan=True):
                     return False
 
             # replace all floats in the "got" string by those from "wanted".

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -29,6 +29,16 @@ def pytest_addoption(parser):
     parser.addoption("--doctest-rst", action="store_true",
                      help="enable running doctests in .rst documentation")
 
+    # Defaults to `atol` parameter from `numpy.allclose`.
+    parser.addoption("--doctest-plus-atol", action="store",
+                     help="set the absolute tolerance for float comparison",
+                     default=1e-08)
+
+    # Defaults to `rtol` parameter from `numpy.allclose`.
+    parser.addoption("--doctest-plus-rtol", action="store",
+                     help="set the relative tolerance for float comparison",
+                     default=1e-05)
+
     parser.addini("doctest_plus", "enable running doctests with additional "
                   "features not found in the normal doctest plugin")
 
@@ -40,16 +50,25 @@ def pytest_addoption(parser):
                   "Run the doctests in the rst documentation",
                   default=False)
 
+    parser.addini("doctest_plus_atol",
+                  "set the absolute tolerance for float comparison",
+                  default=1e-08)
 
-# We monkey-patch in our replacement doctest OutputChecker.  Not
-# great, but there isn't really an API to replace the checker when
-# using doctest.testfile, unfortunately.
-doctest.OutputChecker = OutputChecker
-
-REMOTE_DATA = doctest.register_optionflag('REMOTE_DATA')
+    parser.addini("doctest_plus_rtol",
+                  "set the relative tolerance for float comparison",
+                  default=1e-05)
 
 
 def pytest_configure(config):
+
+    # We monkey-patch in our replacement doctest OutputChecker.  Not
+    # great, but there isn't really an API to replace the checker when
+    # using doctest.testfile, unfortunately.
+    OutputChecker.rtol = float(config.getini("doctest_plus_rtol"))
+    OutputChecker.atol = float(config.getini("doctest_plus_atol"))
+    doctest.OutputChecker = OutputChecker
+
+    REMOTE_DATA = doctest.register_optionflag('REMOTE_DATA')
 
     doctest_plugin = config.pluginmanager.getplugin('doctest')
     if (doctest_plugin is None or config.option.doctestmodules or not

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -64,8 +64,10 @@ def pytest_configure(config):
     # We monkey-patch in our replacement doctest OutputChecker.  Not
     # great, but there isn't really an API to replace the checker when
     # using doctest.testfile, unfortunately.
-    OutputChecker.rtol = float(config.getini("doctest_plus_rtol"))
-    OutputChecker.atol = float(config.getini("doctest_plus_atol"))
+    OutputChecker.rtol = max(float(config.getini("doctest_plus_rtol")),
+                             float(config.getoption("doctest_plus_rtol")))
+    OutputChecker.atol = max(float(config.getini("doctest_plus_atol")),
+                             float(config.getoption("doctest_plus_atol")))
     doctest.OutputChecker = OutputChecker
 
     REMOTE_DATA = doctest.register_optionflag('REMOTE_DATA')


### PR DESCRIPTION
This add two configuration options: `doctest_plus_atol` and `doctest_plus_rtol`. For example, the following configuration would result in the current default comparison:

```
[tool:pytest]
doctest_plus_atol = 1e-08
doctest_plus_rtol = 1e-05
```

Some numerical packages cannot reach the numpy default precision and default object representation (e.g., pandas) prints truncated floating number.