### PR TITLE
Honor the collect_ignore option used in conftest.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.3.0 (unreleased)
 ==================
 
+- Honor the ``collect_ignore`` option used in ``conftest.py``. [#34]
+
 0.2.0 (2018-11-14)
 ==================
 

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -253,6 +253,10 @@ class DoctestPlus(object):
     def pytest_ignore_collect(self, path, config):
         """Skip paths that match any of the doctest_norecursedirs patterns."""
 
+        ignore_paths = config._getconftest_pathlist("collect_ignore",
+                                                    path=path.dirpath())
+        self._ignore_paths = ignore_paths or []
+
         for pattern in config.getini("doctest_norecursedirs"):
             if path.check(fnmatch=pattern):
                 # Apparently pytest_ignore_collect causes files not to be


### PR DESCRIPTION
This resolves #33.

@oscarbenjamin, if you have a chance would you be able to test this in your repo (without using `norecursedirs`)?