### PR TITLE
Inline np.allclose to remove dependency on numpy

### DIFF
--- a/pytest_doctestplus/output_checker.py
+++ b/pytest_doctestplus/output_checker.py
@@ -6,8 +6,7 @@ normalizations of Python expression output.  See the docstring on
 
 import doctest
 import re
-
-import numpy as np
+import math
 
 import six
 from six.moves import zip
@@ -125,8 +124,10 @@ class OutputChecker(doctest.OutputChecker):
                 else:
                     nw_.append(nw)
 
-                if not np.allclose(float(ng), float(nw), rtol=self.rtol,
-                                   atol=self.atol, equal_nan=True):
+                ng = float(ng)
+                nw = float(nw)
+                if not (abs(ng - nw) <= self.atol + self.rtol * abs(nw)
+                        or (math.isnan(ng) and math.isnan(nw))):
                     return False
 
             # replace all floats in the "got" string by those from "wanted".

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'Topic :: Utilities',
     ],
     keywords=[ 'doctest', 'rst', 'pytest', 'py.test' ],
-    install_requires=[ 'six', 'pytest>=2.8.0', 'numpy>=1.10' ],
+    install_requires=[ 'six', 'pytest>=2.8.0'],
     python_requires='>=2.7',
     entry_points={
         'pytest11': [


### PR DESCRIPTION
Using this with sympy pulled in numpy as a dependency. It seems unnecessary to have such a big dependency just for `allclose`. This patch eliminates that dependency by reimplementing allclose for scalars.

The implementation is based on the [documented formula for allclose](https://docs.scipy.org/doc/numpy-1.15.1/reference/generated/numpy.allclose.html)
