### PR TITLE
Add option for global FLOAT_CMP in setup.cfg

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 
 - Make use of ``doctest_optionflags`` settings. [#39]
 
+- Make it possible to set ``FLOAT_CMP`` globally in ``setup.cfg``. [#40]
+
 0.2.0 (2018-11-14)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,16 @@ differences in representation of roundoff digits will be ignored by the
 doctest.  The values are otherwise compared exactly, so more significant
 (albeit possibly small) differences will still be caught by these tests.
 
+This flag can be enabled globally by adding it to ``setup.cfg`` as in
+
+.. code-block:: ini
+
+    doctest_optionflags =
+        NORMALIZE_WHITESPACE
+        ELLIPSIS
+        FLOAT_CMP
+
+
 Skipping Tests
 ~~~~~~~~~~~~~~
 

--- a/pytest_doctestplus/output_checker.py
+++ b/pytest_doctestplus/output_checker.py
@@ -16,11 +16,18 @@ from six.moves import zip
 # borrowed from the SymPy project with permission.  See
 # licenses/SYMPY_LICENSE.rst for the full SymPy license.
 
+
 FIX = doctest.register_optionflag('FIX')
 FLOAT_CMP = doctest.register_optionflag('FLOAT_CMP')
 IGNORE_OUTPUT = doctest.register_optionflag('IGNORE_OUTPUT')
 IGNORE_OUTPUT_2 = doctest.register_optionflag('IGNORE_OUTPUT_2')
 IGNORE_OUTPUT_3 = doctest.register_optionflag('IGNORE_OUTPUT_3')
+
+# These might appear in some doctests and are used in the default pytest
+# doctest plugin. This plugin doesn't actually implement these flags but this
+# allows them to appear in docstrings.
+ALLOW_BYTES = doctest.register_optionflag('ALLOW_BYTES')
+ALLOW_UNICODE = doctest.register_optionflag('ALLOW_UNICODE')
 
 
 class OutputChecker(doctest.OutputChecker):

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -13,7 +13,6 @@ import re
 import sys
 
 import pytest
-from _pytest.doctest import get_optionflags
 
 from .output_checker import OutputChecker, FIX
 
@@ -62,6 +61,14 @@ def pytest_addoption(parser):
     parser.addini("doctest_plus_rtol",
                   "set the relative tolerance for float comparison",
                   default=1e-05)
+
+
+def get_optionflags(parent):
+    optionflags_str = parent.config.getini('doctest_optionflags')
+    flag_int = 0
+    for flag_str in optionflags_str:
+        flag_int |= doctest.OPTIONFLAGS_BY_NAME[flag_str]
+    return flag_int
 
 
 def pytest_configure(config):

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -99,3 +99,29 @@ def test_float_cmp_global(testdir):
     )
     reprec = testdir.inline_run(p, "--doctest-plus")
     reprec.assertoutcome(passed=1)
+
+
+def test_allow_bytes_unicode(testdir):
+    testdir.makeini(
+        """
+        [pytest]
+        doctestplus = enabled
+    """
+    )
+    # These are dummy tests just to check tht doctest-plus can parse the
+    # ALLOW_BYTES and ALLOW_UNICODE options. It doesn't actually implement
+    # these options.
+    p = testdir.makepyfile(
+        """
+        def f():
+            '''
+            >>> 1 # doctest: +ALLOW_BYTES
+            1
+            >>> 1 # doctest: +ALLOW_UNICODE
+            1
+            '''
+            pass
+    """
+    )
+    reprec = testdir.inline_run(p, "--doctest-plus")
+    reprec.assertoutcome(passed=1)

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -6,6 +6,7 @@ def test_ignored_whitespace(testdir):
         """
         [pytest]
         doctest_optionflags = ELLIPSIS NORMALIZE_WHITESPACE
+        doctestplus = enabled
     """
     )
     p = testdir.makepyfile(
@@ -28,6 +29,7 @@ def test_non_ignored_whitespace(testdir):
         """
         [pytest]
         doctest_optionflags = ELLIPSIS
+        doctestplus = enabled
     """
     )
     p = testdir.makepyfile(
@@ -43,3 +45,57 @@ def test_non_ignored_whitespace(testdir):
     )
     reprec = testdir.inline_run(p, "--doctest-plus")
     reprec.assertoutcome(failed=1, passed=0)
+
+
+def test_float_cmp(testdir):
+    testdir.makeini(
+        """
+        [pytest]
+        doctest_optionflags = ELLIPSIS
+        doctestplus = enabled
+    """
+    )
+    p = testdir.makepyfile(
+        """
+        def f():
+            '''
+            >>> x = 1/3.
+            >>> x
+            0.333333
+            '''
+            pass
+
+        def g():
+            '''
+            >>> x = 1/3.
+            >>> x    # doctest: +FLOAT_CMP
+            0.333333
+            '''
+            pass
+    """
+    )
+    reprec = testdir.inline_run(p, "--doctest-plus")
+    reprec.assertoutcome(failed=1, passed=1)
+
+
+def test_float_cmp_global(testdir):
+    testdir.makeini(
+        """
+        [pytest]
+        doctest_optionflags = FLOAT_CMP
+        doctestplus = enabled
+    """
+    )
+    p = testdir.makepyfile(
+        """
+        def f():
+            '''
+            >>> x = 1/3.
+            >>> x
+            0.333333
+            '''
+            pass
+    """
+    )
+    reprec = testdir.inline_run(p, "--doctest-plus")
+    reprec.assertoutcome(passed=1)


### PR DESCRIPTION
Fixes #10 

This extends #39 so that it is possible to set `FLOAT_CMP` globally in `setup.cfg`/`pytest.ini`.

