### PR TITLE
Add doctest_skip and doctest_skipif decorators

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -189,6 +189,45 @@ Having this module-level variable will require ``scipy`` to be importable
 in order to run the doctests for functions ``func1`` and ``func2`` in that
 module.
 
+Doctest skip decorators
+^^^^^^^^^^^^^^^^^^^^^^^
+
+A function or class can be marked with the decorator ``@doctest_skip`` or
+``@doctest_skipif`` to inddicate that it should be skipped when collecting
+doctests.
+
+This can be used to unconditionally skip collection optionally providing a
+reason::
+
+    from pytest_doctestplus import doctest_skip
+
+    @doctest_skip(reason="Integer division")
+    def func1():
+        '''
+        >>> 1/2
+        0.5
+        '''
+        pass
+
+This can also be used to conditionally skip doctests::
+
+    import sys
+    from pytest_doctestplus import doctest_skipif
+
+    @doctest_skipif(sys.version_info < (3,0), "Integer division on Python 2.x")
+    def func1():
+        '''
+        >>> 1/2
+        0.5
+        '''
+        pass
+
+The ``doctest_skipif`` decorator can also accept a callable::
+
+    @doctest_skipif(lambda: not thing_installed(), "Need thing")
+    def func1():
+        ...
+
 Remote Data
 ~~~~~~~~~~~
 

--- a/pytest_doctestplus/__init__.py
+++ b/pytest_doctestplus/__init__.py
@@ -2,3 +2,5 @@
 """
 This package contains pytest plugins that are used by the astropy test suite.
 """
+
+from pytest_doctestplus.skipping import doctest_skip, doctest_skipif

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -15,6 +15,7 @@ import sys
 import pytest
 
 from .output_checker import OutputChecker, FIX
+from .skipping import get_should_skip
 
 
 # these pytest hooks allow us to mark tests and run the marked tests with
@@ -408,3 +409,13 @@ class DocTestFinderPlus(doctest.DocTestFinder):
             tests = list(filter(test_filter, tests))
 
         return tests
+
+    def _find(self, tests, obj, name, module, source_lines, globs, seen):
+        # This method of DocTestFinder calls itself recursively descending
+        # over all attributes of obj looking for docstrings that may contain
+        # doctests. We override it here so that we can skip collecting
+        # doctests from objects marked with @doctest_skip.
+        if get_should_skip(obj):
+            return
+        doctest.DocTestFinder._find(self, tests, obj, name, module,
+                                          source_lines, globs, seen)

--- a/pytest_doctestplus/skipping.py
+++ b/pytest_doctestplus/skipping.py
@@ -1,0 +1,49 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Defines the doctest_skip decorator.
+"""
+
+SHOULD_SKIP = {}
+
+def doctest_skip(reason=None):
+    '''Mark a function/class so that doctests are skipped.
+
+    An optional reason can be given.
+    '''
+    # Reason is currently ignored. Maybe there's a way to report it somehow...
+    def decorator(obj):
+        SHOULD_SKIP[obj] = True
+        return obj
+
+    return decorator
+
+def doctest_skipif(condition, reason=None):
+    '''Mark a function/class so that doctests are skipped conditionally.
+
+    condition can be bool or a callable (returning bool).
+    An optional reason can be given
+    '''
+    # Reason is currently ignored. Maybe there's a way to report it somehow...
+
+    if not (condition in (True, False) or callable(condition)):
+        raise ValueError('condition should be bool or callable')
+
+    def decorator(obj):
+        SHOULD_SKIP[obj] = condition
+        return obj
+
+    return decorator
+
+def get_should_skip(obj):
+    '''Check if obj has been marked with doctest_skip or doctest_skipif.
+
+    In the case of doctest_skipif this will return the result of the skipif
+    condition.
+    '''
+    condition = SHOULD_SKIP.get(obj, False)
+    if condition in (True, False):
+        return condition
+    elif callable(condition):
+        return condition()
+    else:
+        raise ValueError('condition should be bool or callable')

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -125,3 +125,177 @@ def test_allow_bytes_unicode(testdir):
     )
     reprec = testdir.inline_run(p, "--doctest-plus")
     reprec.assertoutcome(passed=1)
+
+
+def test_doctest_skip(testdir):
+    testdir.makeini(
+        """
+        [pytest]
+        doctestplus = enabled
+    """
+    )
+    p = testdir.makepyfile(
+        """
+        from pytest_doctestplus import doctest_skip
+
+        @doctest_skip("need to skip...")
+        def f():
+            '''
+            >>> 1/0
+            '''
+            return 2
+
+        # Check the function still works:
+        assert f() == 2
+    """
+    )
+    reprec = testdir.inline_run(p, "--doctest-plus")
+    reprec.assertoutcome(passed=0, failed=0)
+
+
+def test_doctest_skip_class(testdir):
+    testdir.makeini(
+        """
+        [pytest]
+        doctestplus = enabled
+    """
+    )
+    p = testdir.makepyfile(
+        """
+        from pytest_doctestplus import doctest_skip
+
+        @doctest_skip("need to skip...")
+        class Thing(object):
+            '''
+            >>> 1/0
+            '''
+            def meth(self):
+                '''
+                >>> 1/0
+                '''
+                pass
+
+        class SubThing1(Thing):
+            '''
+            >>> 1+1
+            2
+            '''
+            def meth(self):
+                '''
+                >>> 1+2
+                3
+                '''
+                pass
+
+        class SubThing2(Thing):
+            '''
+            >>> 1+1
+            2
+            '''
+            @doctest_skip("skip only this...")
+            def meth(self):
+                '''
+                >>> 1/0
+                '''
+                pass
+    """
+    )
+    reprec = testdir.inline_run(p, "--doctest-plus")
+    reprec.assertoutcome(passed=3, failed=0)
+
+
+def test_doctest_skipif(testdir):
+    testdir.makeini(
+        """
+        [pytest]
+        doctestplus = enabled
+    """
+    )
+    p = testdir.makepyfile(
+        """
+        from pytest_doctestplus import doctest_skipif
+
+        @doctest_skipif(True, "will skip")
+        def f():
+            '''
+            >>> 1/0
+            '''
+            return 3
+
+        @doctest_skipif(False, "won't skip")
+        def g():
+            '''
+            >>> 1+1
+            2
+            '''
+            return 4
+
+        assert f() == 3
+        assert g() == 4
+
+    """
+    )
+    reprec = testdir.inline_run(p, "--doctest-plus")
+    reprec.assertoutcome(passed=1, failed=0)
+
+
+def test_doctest_skipif_callable(testdir):
+    testdir.makeini(
+        """
+        [pytest]
+        doctestplus = enabled
+    """
+    )
+    p = testdir.makepyfile(
+        """
+        from pytest_doctestplus import doctest_skipif
+
+        @doctest_skipif(lambda: True, "will skip")
+        def f():
+            '''
+            >>> 1/0
+            '''
+            return 3
+
+        @doctest_skipif(lambda: False, "won't skip")
+        def g():
+            '''
+            >>> 1+1
+            2
+            '''
+            return 4
+
+        assert f() == 3
+        assert g() == 4
+
+    """
+    )
+    reprec = testdir.inline_run(p, "--doctest-plus")
+    reprec.assertoutcome(passed=1, failed=0)
+
+
+def test_doctest_skipif_callable_delayed_check(testdir):
+    testdir.makeini(
+        """
+        [pytest]
+        doctestplus = enabled
+    """
+    )
+    p = testdir.makepyfile(
+        """
+        from pytest_doctestplus import doctest_skipif
+
+        @doctest_skipif(lambda: not installed, "skip if _nonexistent_ not installed")
+        def f():
+            '''
+            >>> 1/0
+            '''
+            return 3
+
+        installed = False
+
+        assert f() == 3
+    """
+    )
+    reprec = testdir.inline_run(p, "--doctest-plus")
+    reprec.assertoutcome(passed=0, failed=0)


### PR DESCRIPTION
This patch adds two new decorators `doctest_skip` and `doctest_skipif` that can be used to mark an object so that doctests are not collected from it.

The `doctest_skip` decorator is for unconditional skipping so is partly redundant given `__doctest_skip__`. However the `doctest_skipif` decoartor is not redundant since doctestplus currently doesn't provide any way to skip based on arbitrary conditions.