### PR TITLE
Make doctestplus work for TeX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,3 +49,4 @@ install:
 script:
    - $PYTEST_COMMAND --doctest-plus
    - $PYTEST_COMMAND --doctest-plus --doctest-rst
+   - $PYTEST_COMMAND --doctest-plus --doctest-rst --text-file-format=tex

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,13 +9,17 @@
 
 - Drop support for ``pytest`` versions earlier than 3.0. [#46]
 
+- Extend ``doctest-skip``, ``doctest-skip-all``, and ``doctest-requires``
+  directives to work in TeX files. [#43]
+
+
 0.2.0 (2018-11-14)
 ==================
 
-- Add `doctest-plus-atol` and `doctest-plus-rtol` options for setting the
+- Add ``doctest-plus-atol`` and ``doctest-plus-rtol`` options for setting the
   numerical tolerance. [#21]
 
-- Update behavior of `--doctest-modules` option when plugin is installed. [#26]
+- Update behavior of ``--doctest-modules`` option when plugin is installed. [#26]
 
 0.1.3 (2018-04-20)
 ==================

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,3 +56,4 @@ build: false
 test_script:
   - "%CMD_IN_ENV% %PYTEST_COMMAND% --doctest-plus"
   - "%CMD_IN_ENV% %PYTEST_COMMAND% --doctest-plus --doctest-rst"
+  - "%CMD_IN_ENV% %PYTEST_COMMAND% --doctest-plus --doctest-rst --text-file-format=tex"

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -227,7 +227,12 @@ def pytest_configure(config):
                     matches = [re.match(
                         r'{}\s+doctest-skip\s*::(\s+.*)?'.format(comment_char),
                         last_line) for last_line in last_lines]
-                    match = matches[0] or matches[1]
+
+                    if len(matches) > 1:
+                        match = matches[0] or matches[1]
+                    else:
+                        match = matches[0]
+
                     if match:
                         marker = match.group(1)
                         if (marker is None or
@@ -239,7 +244,12 @@ def pytest_configure(config):
                     matches = [re.match(
                         r'{}\s+doctest-requires\s*::\s+(.*)'.format(comment_char),
                         last_line) for last_line in last_lines]
-                    match = matches[0] or matches[1]
+
+                    if len(matches) > 1:
+                        match = matches[0] or matches[1]
+                    else:
+                        match = matches[0]
+
                     if match:
                         required = re.split(r'\s*,?\s*', match.group(1))
                 elif isinstance(entry, doctest.Example):

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -18,7 +18,7 @@ from .output_checker import OutputChecker, FIX
 
 comment_characters = {'txt': '#',
                       'tex': '%',
-                      'rst': '..'
+                      'rst': '\.\.'
                       }
 
 
@@ -203,7 +203,7 @@ def pytest_configure(config):
             skip_next = False
             skip_all = False
 
-            comment_char = '..'
+            comment_char = '\.\.'
             for entry in result:
                 if isinstance(entry, six.string_types) and entry:
                     file_format = config.getoption('text_file_format', None)
@@ -214,7 +214,7 @@ def pytest_configure(config):
                     required = []
                     skip_next = False
                     lines = entry.strip().splitlines()
-                    if '{} doctest-skip-all'.format(comment_char) in (x.strip() for x in lines):
+                    if any([re.match('{} doctest-skip-all'.format(comment_char), x.strip()) for x in lines]):
                         skip_all = True
                         continue
 

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -203,14 +203,13 @@ def pytest_configure(config):
             skip_next = False
             skip_all = False
 
-            comment_char = '\.\.'
+            file_format = config.getoption('text_file_format', 'rst')
+
+            if file_format in comment_characters:
+                comment_char = comment_characters[file_format]
+
             for entry in result:
                 if isinstance(entry, six.string_types) and entry:
-                    file_format = config.getoption('text_file_format', None)
-
-                    if file_format in comment_characters:
-                        comment_char = comment_characters[file_format]
-
                     required = []
                     skip_next = False
                     lines = entry.strip().splitlines()

--- a/tests/docs/skip_all.tex
+++ b/tests/docs/skip_all.tex
@@ -1,0 +1,54 @@
+% doctest-skip-all
+
+\documentclass{article}
+\setlength{\parindent}{0cm}
+
+\usepackage{listings}
+\lstnewenvironment{python}[1][]{
+\lstset{
+language=python,
+}}{}
+
+\begin{document}
+
+\section{Some Bad Test Cases}
+
+All of the example code blocks in this file are going to fail if they run. So
+if the directive used at the top of this file does not work, then there are
+going to be test failures.
+
+\subsection{Undefined Variables}
+
+This one will fail because the variables haven't been defined::
+
+\begin{python}
+>>> x + y
+5
+
+\end{python}
+
+
+\subsection{No Such Module}
+
+This one will fail because there's (probably) no such module::
+
+\begin{python}
+>>> import foobar
+>>> foobar.baz(42)
+0
+
+\end{python}
+
+
+\section{What???}
+
+This one will fail because it's just not valid python::
+
+\begin{python}
+>>> NOT VALID PYTHON, OKAY?
+>>> + 5
+10
+
+\end{python}
+
+\end{document}

--- a/tests/docs/skip_some.tex
+++ b/tests/docs/skip_some.tex
@@ -1,0 +1,91 @@
+\documentclass{article}
+\setlength{\parindent}{0cm}
+
+\usepackage{listings}
+\lstnewenvironment{python}[1][]{
+\lstset{
+language=python,
+}}{}
+
+\begin{document}
+
+Some of the example code blocks in this file are perfectly valid and will pass
+if they run. Some are not. The intent of this file is to test the directives
+that are provided by the ``--doctest-text'' option to make sure that the bad
+ones get skipped.
+
+\section{Here's One That Works}
+
+This code block should work just fine::
+
+\begin{python}
+>>> 1 + 1
+2
+
+\end{python}
+
+This one should work just fine as well::
+
+\begin{python}
+>>> x = 5
+>>> x
+5
+
+\end{python}
+
+\section{Here's One That Doesn't}
+
+This code won't run. So let's make sure that it gets skipped:
+
+% doctest-skip::
+\begin{python}
+>>> y + z
+42
+
+\end{python}
+
+This one doesn't work either:
+
+% doctest-skip::
+\begin{python}
+>>> print(blue)
+'blue'
+
+\end{python}
+
+\section{Good Imports}
+
+There should be nothing wrong with this code, so we'll let it run:
+
+\begin{python}
+>>> import os
+>>> os.path.curdir
+'.'
+
+\end{python}
+
+Make sure the `doctest-requires` directive works for modules that are
+available:
+
+% doctest-requires:: sys
+\begin{python}
+>>> import sys
+
+\end{python}
+
+
+\section{Bad Imports}
+
+
+I don't think this module exists, so we should make sure that this code doesn't
+run:
+
+% doctest-requires:: foobar
+\begin{python}
+>>> import foobar
+>>> foobar.baz(42)
+1
+
+\end{python}
+
+\end{document}


### PR DESCRIPTION
This should fix #42 

The system is now flexible so can be extend with other text file extensions and comment characters.