### PR TITLE
Drop support for pytest versions earlier than 3.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@
 
 - Make it possible to set ``FLOAT_CMP`` globally in ``setup.cfg``. [#40]
 
+- Drop support for ``pytest`` versions earlier than 3.0. [#46]
+
 0.2.0 (2018-11-14)
 ==================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
-[pytest]
-minversion = 2.8
+[tool:pytest]
+minversion = 3.0
 testpaths = tests

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         'Topic :: Utilities',
     ],
     keywords=[ 'doctest', 'rst', 'pytest', 'py.test' ],
-    install_requires=[ 'six', 'pytest>=2.8.0', 'numpy>=1.10' ],
+    install_requires=[ 'six', 'pytest>=3.0', 'numpy>=1.10' ],
     python_requires='>=2.7',
     entry_points={
         'pytest11': [


### PR DESCRIPTION
This resolves #45.