### PR TITLE
Fixing precedent and few corner cases

### DIFF
--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -11,6 +11,7 @@ import imp
 import os
 import re
 import sys
+import warnings
 
 import pytest
 
@@ -207,6 +208,9 @@ def pytest_configure(config):
             if file_format in comment_characters:
                 comment_char = comment_characters[file_format]
             else:
+                warnings.warn("file format '{}' is not recognized, assuming "
+                              "'{}' as the comment character."
+                              .format(file_format, comment_characters['rst']))
                 comment_char = comment_characters['rst']
 
             for entry in result:


### PR DESCRIPTION
This is a follow-up for #43 as with that one I run into a few corner cases.

- now possible to set the format in `pytest.ini` only (previously the comment string wasn't picked up correctly for that case)
- now the comment character defaults to the one for `rst` format, so when a non mapped format is specified the test is not failing with undefined variable, but runs the doctest with a warning.
- this PR not makes it possible to override the `pytest.ini` value for the format on the command line

Missing feature, but it's beyond this PR is to make it possible to make the formats and comment characters configurable.

(also, it seems that `config.getoptio()` is not working as expected, at least it didn't picked up the default specified rather it defaulted to None)
