### PR TITLE
Add (xfail) test showing incompatibility between FLOAT_CMP and ELLIPSIS

### DIFF
--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -1,3 +1,5 @@
+import pytest
+
 pytest_plugins = ['pytester']
 
 
@@ -97,6 +99,30 @@ def test_float_cmp_global(testdir):
             pass
     """
     )
+    reprec = testdir.inline_run(p, "--doctest-plus")
+    reprec.assertoutcome(passed=1)
+
+
+@pytest.mark.xfail(reason='FLOAT_CMP and ELLIPSIS are not currently compatible')
+def test_float_cmp_and_ellipsis(testdir):
+    testdir.makeini(
+        """
+        [pytest]
+        doctest_optionflags = FLOAT_CMP ELLIPSIS
+        doctestplus = enabled
+    """)
+    p = testdir.makepyfile(
+        """
+        def f():
+            '''
+            >>> for char in ['A', 'B', 'C', 'D', 'E']:
+            ...     print(char, float(ord(char)))
+            A 65.0
+            B 66.0
+            ...
+            '''
+            pass
+    """)
     reprec = testdir.inline_run(p, "--doctest-plus")
     reprec.assertoutcome(passed=1)
 


### PR DESCRIPTION
This came to light in https://github.com/astropy/astropy/pull/8495. This problem has probably existed for a long time, but now that it is possible to set both `FLOAT_CMP` and `ELLIPSIS` as global settings (thanks to #40), it is now evident in certain test cases.