### PR TITLE
Avoid the imp deprecation warning, yet keep python2 support

### DIFF
--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -7,11 +7,13 @@ import six
 
 import doctest
 import fnmatch
-import imp
+import importlib
 import os
 import re
 import sys
 import warnings
+
+from distutils.version import LooseVersion
 
 import pytest
 
@@ -400,9 +402,17 @@ class DocTestFinderPlus(doctest.DocTestFinder):
             if mod in cls._import_cache:
                 if not cls._import_cache[mod]:
                     return False
-            try:
-                imp.find_module(mod)
-            except ImportError:
+
+            if LooseVersion(sys.version) < LooseVersion('3.4'):
+                import imp
+                try:
+                    module = imp.find_module(mod)
+                except ImportError:
+                    module = None
+            else:
+                module = importlib.find_loader(mod)
+
+            if module is None:
                 cls._import_cache[mod] = False
                 return False
             else:


### PR DESCRIPTION
Ugly but works, and frankly I can't wait to remove the python2 support anyway.

Before this PR I see:
```
/usr/local/lib/python3.7/site-packages/pytest_doctestplus/plugin.py:10: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
```