### PR TITLE
Avoid SyntaxWarning regarding invalid escape sequence in newer Python versions

### DIFF
--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -19,7 +19,7 @@ from .output_checker import OutputChecker, FIX
 
 comment_characters = {'txt': '#',
                       'tex': '%',
-                      'rst': '\.\.'
+                      'rst': r'\.\.'
                       }
 
 


### PR DESCRIPTION
I've noticed this `SyntaxWarning` in an output done with Python 3.9 (see [here](https://gist.github.com/cdeil/9586f0c3666d1afe3132a290ce92fc5f)).