### PR TITLE
Compatibility with pytest 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,11 @@ matrix:
           env: PYTHON_VERSION=3.7
 
         # Try a run against latest pytest
-        - env: PYTHON_VERSION=3.7 PYTEST_VERSION=4
+        - env: PYTHON_VERSION=3.7 PYTEST_VERSION=5
 
-    allow_failures:
-        - env: PYTHON_VERSION=3.7 PYTEST_VERSION=4
+# COMMENTED OUT FOR NOW
+#    allow_failures:
+#        - env: PYTHON_VERSION=3.7 PYTEST_VERSION=5
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -160,7 +160,7 @@ def pytest_configure(config):
             failed, tot = doctest.testfile(
                 str(self.fspath), module_relative=False,
                 optionflags=options, parser=DocTestParserPlus(),
-                extraglobs=dict(getfixture=fixture_request.getfuncargvalue),
+                extraglobs=dict(getfixture=fixture_request.getfixturevalue),
                 raise_on_error=True, verbose=False, encoding='utf-8')
 
         def reportinfo(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
 [tool:pytest]
 minversion = 3.0
 testpaths = tests
+xfail_strict=true
+filterwarnings =
+    error

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,4 @@ testpaths = tests
 xfail_strict=true
 filterwarnings =
     error
+    ignore:file format.*:UserWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,4 @@ xfail_strict=true
 filterwarnings =
     error
     ignore:file format.*:UserWarning
+    ignore:.*non-empty pattern match.*:FutureWarning


### PR DESCRIPTION
See https://github.com/pytest-dev/pytest/releases/tag/5.1.0 . This is to fix:
```
E   AttributeError: 'FixtureRequest' object has no attribute 'getfuncargvalue'
```

Example log: https://circleci.com/gh/astropy/astropy/40431

p.s. How far back do we need to be backward compatible? Or is a simple renaming like this okay?

xref pytest-dev/pytest#2682