### PR TITLE
fix doctest requires sphinx directive

### DIFF
--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -257,7 +257,10 @@ def pytest_configure(config):
                         match = matches[0]
 
                     if match:
-                        required = re.split(r'\s*,?\s*', match.group(1))
+                        # sys - ok
+                        # sys, sys - ok
+                        # sys,sys - not ok
+                        required = re.split(r'\s*,?\s+', match.group(1))
                 elif isinstance(entry, doctest.Example):
                     if (skip_all or skip_next or
                         not DocTestFinderPlus.check_required_modules(required)):

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -201,3 +201,45 @@ def test_allow_bytes_unicode(testdir):
     )
     reprec = testdir.inline_run(p, "--doctest-plus")
     reprec.assertoutcome(passed=1)
+
+
+def test_requires(testdir):
+    testdir.makeini(
+        """
+        [pytest]
+        doctestplus = enabled
+    """)
+
+    # should be ignored
+    p = testdir.makefile(
+        '.rst',
+        """
+        .. doctest-requires:: foobar
+
+            >>> import foobar
+        """
+    )
+    testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(passed=1)
+
+    # should run as expected
+    p = testdir.makefile(
+        '.rst',
+        """
+        .. doctest-requires:: sys
+
+            >>> import sys
+        """
+    )
+    testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(passed=1)
+
+    # testing this in case if doctest-requires just ignores everything
+    p = testdir.makefile(
+        '.rst',
+        """
+        .. doctest-requires:: sys
+
+            >>> import sys
+            >>> assert 0
+        """
+    )
+    testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(failed=1)


### PR DESCRIPTION
close #57
close #29

Old regex `\s*,?\s*` used in re.split produces `['s', 'y', 's']` from string `'sys'`.

New regex `\s*,?\s+`:
- `'sys'` -> `['sys']`
- `'sys pandas'` -> `['sys', 'pandas']`
- `'sys, pandas'` -> `['sys', 'pandas']`
- `'sys,pandas'` -> `['sys,pandas']` - at least one space should be after comma
- `'sys     ,    pandas'` -> `['sys', 'pandas']`