### PR TITLE
allow to specify module version doctest-requires sphinx directive

### DIFF
--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -256,7 +256,8 @@ def pytest_configure(config):
                         match = matches[0]
 
                     if match:
-                        required = re.split(r'\s*,?\s*', match.group(1))
+                        # 'a a' or 'a,a' or 'a, a'-> [a, a]
+                        required = re.split(r'\s*[,\s]\s*', match.group(1))
                 elif isinstance(entry, doctest.Example):
                     if (skip_all or skip_next or
                         not DocTestFinderPlus.check_required_modules(required)):

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -398,11 +398,17 @@ class DocTestFinderPlus(doctest.DocTestFinder):
 
     @classmethod
     def check_required_modules(cls, mods):
-        """
-        Check that modules in :attr:`mods` list are available.
-        :param mods: list of module names. Modules can have specified versions
-          (eg 'numpy>=1.15')
-        :return: True if all modules are available.
+        """Check that modules in `mods` list are available.
+
+        Parameters
+        ----------
+        mods : list of str
+            List of modules. Modules can have specified versions (eg 'numpy>=1.15')
+
+        Returns
+        -------
+        bool
+            True if all modules in list are available.
         """
         for mod in mods:
             if mod in cls._import_cache:

--- a/pytest_doctestplus/utils.py
+++ b/pytest_doctestplus/utils.py
@@ -49,7 +49,7 @@ class ModuleChecker:
         match = re.match(r'([A-Za-z0-9-_]+)([^A-Za-z0-9-_]+)([\d.]+$)', module)
         if not match:
             return False
-        package, cmp, version = match[1], match[2], match[3]
+        package, cmp, version = match.groups()
         package = package.lower()
 
         if package in self.packages:

--- a/pytest_doctestplus/utils.py
+++ b/pytest_doctestplus/utils.py
@@ -1,0 +1,93 @@
+import logging
+import operator
+import re
+import subprocess
+import sys
+from distutils.version import LooseVersion
+
+logger = logging.getLogger(__name__)
+
+
+class ModuleChecker:
+    def __init__(self):
+        if LooseVersion(sys.version) < LooseVersion('3.4'):
+            import imp
+            self._find_module = imp.find_module
+            self._find_distribution = self._check_distribution
+            self.packages = self.get_packages()
+        else:
+            import importlib.util
+            import pkg_resources
+            self._find_module = importlib.util.find_spec
+            self._find_distribution = pkg_resources.require
+            self.packages = {}
+
+    def get_packages(self):
+        packages = subprocess.check_output([sys.executable, '-m', 'pip', 'freeze']).decode().splitlines()
+        packages = [package.split('==') for package in packages if '==' in package]
+        return {name.lower(): version for name, version in packages}
+
+    def compare_versions(self, v1, v2, op):
+        op_map = {
+            '<': operator.lt,
+            '<=': operator.le,
+            '>': operator.gt,
+            '>=': operator.ge,
+            '==': operator.eq,
+        }
+        if op not in op_map:
+            return False
+        op = op_map[op]
+        return op(LooseVersion(v1), LooseVersion(v2))
+
+    def _check_distribution(self, module):
+        """
+        Python 2 (and <3.4) compatible version of pkg_resources.require.
+        But unlike pkg_resources.require it just checks whether package is
+        installed and has required version.
+        """
+        match = re.match(r'([A-Za-z0-9-_]+)([^A-Za-z0-9-_]+)([\d.]+$)', module)
+        if not match:
+            return False
+        package, cmp, version = match[1], match[2], match[3]
+        package = package.lower()
+
+        if package in self.packages:
+            installed_version = self.packages[package]
+            if self.compare_versions(installed_version, version, cmp):
+                return True
+            else:
+                logger.warning(
+                    "{} {} is installed. Version {}{} is required".format(
+                        package, installed_version, cmp, version
+                    )
+                )
+                return False
+        logger.warning("The '{}' distribution was not found and is required by the application".format(package))
+        return False
+
+    def find_module(self, module):
+        """Search for modules specification."""
+        try:
+            return self._find_module(module)
+        except ImportError:
+            return None
+
+    def find_distribution(self, dist):
+        """Search for distribution with specified version (eg 'numpy>=1.15')."""
+        try:
+            return self._find_distribution(dist)
+        except Exception as e:
+            logger.warning(e)
+            return None
+
+    def check(self, module):
+        """
+        Return True if module with specified version exists.
+        >>> ModuleChecker().check('foo>=1.0')
+        False
+        >>> ModuleChecker().check('pytest>1.0')
+        True
+        """
+        mods = self.find_module(module) or self.find_distribution(module)
+        return bool(mods)

--- a/tests/docs/skip_some.rst
+++ b/tests/docs/skip_some.rst
@@ -64,3 +64,19 @@ run:
     >>> import foobar
     >>> foobar.baz(42)
     1
+
+
+Package version
+===============
+
+Code in doctest should run only if version condition is satisfied:
+
+.. doctest-requires:: numpy<=0.1
+
+    >>> import numpy
+    >>> assert 0
+
+
+.. doctest-requires:: pytest>=1.0 pytest>=2.0
+
+    >>> import pytest

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -360,7 +360,7 @@ def test_requires(testdir):
     )
     testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(passed=1)
 
-    # testing this in case if doctest-requires just ignores everything
+    # testing this in case if doctest-requires just ignores everything and pass unconditionally
     p = testdir.makefile(
         '.rst',
         """
@@ -370,3 +370,25 @@ def test_requires(testdir):
         """
     )
     testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(failed=1)
+
+    # package with version is available
+    p = testdir.makefile(
+        '.rst',
+        """
+        .. doctest-requires:: sys pytest>=1.0
+            >>> import sys, pytest
+        """
+    )
+    testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(passed=1)
+
+    # package with version is not available
+    p = testdir.makefile(
+        '.rst',
+        """
+        .. doctest-requires:: sys pytest<1.0 glob
+            >>> import sys, pytest, glob
+            >>> assert 0
+        """
+    )
+    # passed because 'pytest<1.0' was not satisfied and 'assert 0' was not evaluated
+    testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(passed=1)

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -331,3 +331,42 @@ class TestFloats:
             [str(i) for i in range(20)],
             [[], ['1', '2'], ['7'], ['6'], []],
         )
+
+
+def test_requires(testdir):
+    testdir.makeini(
+        """
+        [pytest]
+        doctestplus = enabled
+    """)
+
+    # should be ignored
+    p = testdir.makefile(
+        '.rst',
+        """
+        .. doctest-requires:: foobar
+            >>> import foobar
+        """
+    )
+    testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(passed=1)
+
+    # should run as expected
+    p = testdir.makefile(
+        '.rst',
+        """
+        .. doctest-requires:: sys
+            >>> import sys
+        """
+    )
+    testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(passed=1)
+
+    # testing this in case if doctest-requires just ignores everything
+    p = testdir.makefile(
+        '.rst',
+        """
+        .. doctest-requires:: sys glob, re,math
+            >>> import sys
+            >>> assert 0
+        """
+    )
+    testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(failed=1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,25 @@
+from pytest_doctestplus.utils import ModuleChecker
+
+
+class TestModuleChecker:
+    def test_simple(self):
+        c = ModuleChecker()
+        assert c.check('sys')
+        assert not c.check('foobar')
+
+    def test_with_version(self):
+        c = ModuleChecker()
+        assert c.check('pytest>1.0')
+        assert not c.check('foobar>1.0')
+
+    def test_check_distribution(self):
+        c = ModuleChecker()
+        # in python3.4+ packages attribute will not be populated
+        # because it calls 'pip freeze' which is slow
+        if not c.packages:
+            c.packages = c.get_packages()
+            # after this we will be able to test _check_distribution even in
+            # python3.4+ environment
+        assert c._check_distribution('pytest>1.0')
+        assert not c._check_distribution('pytest<1.0')
+        assert not c._check_distribution('foobar>1.0')


### PR DESCRIPTION
close #57
close #29
close #18

### Note 1 - split regex

Old regex `\s*,?\s*` used in re.split produces `['s', 'y', 's']` from string `'sys'`.

New regex `\s*[,\s]\s*`:

    'sys' -> ['sys']
    'sys pandas' -> ['sys', 'pandas']
    'sys, pandas<=123' -> ['sys', 'pandas<=123']
    'sys,pandas' -> ['sys', 'pandas']
    'sys , pandas' -> ['sys', 'pandas']

### Note 2 - getting package versions

For python3.4+ there is `pkg_resources.require` to check that package with specified version is available. 

For python2 (which should be already dropped) I wrote custom version checker which essentially just pull packages info from `pip freeze` output and compare versions using `distutils.version.LooseVersion`.
`pip freeze`  is triggered only for python3.4-. 
