### PR TITLE
add doctest-only option

### DIFF
--- a/pytest_doctestplus/output_checker.py
+++ b/pytest_doctestplus/output_checker.py
@@ -18,6 +18,7 @@ from six.moves import zip
 
 FIX = doctest.register_optionflag('FIX')
 FLOAT_CMP = doctest.register_optionflag('FLOAT_CMP')
+REMOTE_DATA = doctest.register_optionflag('REMOTE_DATA')
 IGNORE_OUTPUT = doctest.register_optionflag('IGNORE_OUTPUT')
 IGNORE_OUTPUT_2 = doctest.register_optionflag('IGNORE_OUTPUT_2')
 IGNORE_OUTPUT_3 = doctest.register_optionflag('IGNORE_OUTPUT_3')
@@ -40,6 +41,8 @@ class OutputChecker(doctest.OutputChecker):
       string representation.  This naturally supports complex numbers as well
       (simply by comparing their real and imaginary parts separately).
     """
+    rtol = 1e-05
+    atol = 1e-08
 
     _original_output_checker = doctest.OutputChecker
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [tool:pytest]
 minversion = 3.0
-testpaths = tests
+testpaths = tests pytest_doctestplus
 xfail_strict=true
 filterwarnings =
     error

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+from functools import partial
+import textwrap
+
+import pytest
+
+
+def _wrap_docstring_in_func(func_name, docstring):
+    template = textwrap.dedent(r"""
+        def {}():
+            r'''
+        {}
+            '''
+    """)
+    return template.format(func_name, docstring)
+
+
+@pytest.fixture
+def makepyfile(testdir):
+    """Fixture for making python files with single function and docstring."""
+    def make(*args, **kwargs):
+        func_name = kwargs.pop('func_name', 'f')
+        # content in args and kwargs is treated as docstring
+        wrap = partial(_wrap_docstring_in_func, func_name)
+        args = map(wrap, args)
+        kwargs = dict(zip(kwargs.keys(), map(wrap, kwargs.values())))
+        return testdir.makepyfile(*args, **kwargs)
+
+    return make
+
+
+@pytest.fixture
+def maketestfile(makepyfile):
+    """Fixture for making python test files with single function and docstring."""
+    def make(*args, **kwargs):
+        func_name = kwargs.pop('func_name', 'test_foo')
+        return makepyfile(*args, func_name=func_name, **kwargs)
+
+    return make
+
+
+@pytest.fixture
+def makerstfile(testdir):
+    """Fixture for making rst files with specified content."""
+    def make(*args, **kwargs):
+        return testdir.makefile('.rst', *args, **kwargs)
+
+    return make

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -1,5 +1,3 @@
-import pytest
-
 import doctest
 from pytest_doctestplus.output_checker import OutputChecker, FLOAT_CMP
 
@@ -392,3 +390,27 @@ def test_requires(testdir):
     )
     # passed because 'pytest<1.0' was not satisfied and 'assert 0' was not evaluated
     testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(passed=1)
+
+
+def test_doctest_only(testdir, makepyfile, maketestfile, makerstfile):
+    # regular python files with doctests
+    makepyfile(p1='>>> 1 + 1\n2')
+    makepyfile(p2='>>> 1 + 1\n3')
+    # regular test files
+    maketestfile(test_1='foo')
+    maketestfile(test_2='bar')
+    # rst files
+    makerstfile(r1='>>> 1 + 1\n2')
+    makerstfile(r3='>>> 1 + 1\n3')
+    makerstfile(r2='>>> 1 + 2\n3')
+
+    # regular tests
+    testdir.inline_run().assertoutcome(passed=2)
+    # regular + doctests
+    testdir.inline_run("--doctest-plus").assertoutcome(passed=3, failed=1)
+    # regular + doctests + doctest in rst files
+    testdir.inline_run("--doctest-plus", "--doctest-rst").assertoutcome(passed=5, failed=2)
+    # only doctests in python files, implicit usage of doctest-plus
+    testdir.inline_run("--doctest-only").assertoutcome(passed=1, failed=1)
+    # only doctests in python files
+    testdir.inline_run("--doctest-only", "--doctest-rst").assertoutcome(passed=3, failed=2)


### PR DESCRIPTION
close #14

### details

`--doctest-only` will implicitly use doctest-plus and will filter out all python test files (`python_files` in `pytest.ini`, eg `test_*.py`).

check out `test_doctest_only` for usage details https://github.com/astropy/pytest-doctestplus/blob/b1da7f4d0b4f4b6e2dc3423f42f715732a4cca80/tests/test_doctestplus.py#L395-L416
