### PR TITLE
use doctest-glob instead of doctest-rst and text-file-format

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,10 @@
 0.5.0 (unreleased)
 ==================
 
-- No changes yet.
+- Make comment character configurable via ini variable
+  text_file_comment_chars [#48]
+
+- Allow to use doctest-glob option instead of doctest-rst and text-file-format [#9]
 
 
 0.4.0 (2019-09-17)

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -62,11 +62,17 @@ def pytest_addoption(parser):
                      "plugin")
 
     parser.addoption("--doctest-rst", action="store_true",
-                     help="DEPRECATED, use doctest-glob. Enable running doctests in .rst documentation.")
+                     help=(
+                         "Enable running doctests in .rst documentation. "
+                         "This is no longer recommended, use --doctest-glob instead."
+                     ))
 
     parser.addoption("--text-file-format", action="store",
-                     help=("Text file format for narrative documentation. "
-                           "Options accepted are 'txt', 'tex', and 'rst'"))
+                     help=(
+                        "Text file format for narrative documentation. "
+                        "Options accepted are 'txt', 'tex', and 'rst'. "
+                        "This is no longer recommended, use --doctest-glob instead."
+                     ))
 
     # Defaults to `atol` parameter from `numpy.allclose`.
     parser.addoption("--doctest-plus-atol", action="store",
@@ -78,7 +84,9 @@ def pytest_addoption(parser):
                      help="set the relative tolerance for float comparison",
                      default=1e-05)
 
-    parser.addini("text_file_format", "DEPRECATED, use doctest-glob. Default format for docs.")
+    parser.addini("text_file_format",
+                  "Default format for docs. "
+                  "This is no longer recommended, use --doctest-glob instead.")
 
     parser.addini("doctest_optionflags", "option flags for doctests",
                   type="args", default=["ELLIPSIS", "NORMALIZE_WHITESPACE"],)

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -102,6 +102,11 @@ def pytest_addoption(parser):
                   "set the relative tolerance for float comparison",
                   default=1e-05)
 
+    parser.addini('text_file_comment_chars',
+                  help='list of pairs in format file_extension=comment_chars, eg: .rst=..',
+                  type='linelist',
+                  default=[])
+
 
 def get_optionflags(parent):
     optionflags_str = parent.config.getini('doctest_optionflags')
@@ -135,8 +140,10 @@ def pytest_configure(config):
     if use_rst:
         config.option.doctestglob.append('*.{}'.format(file_ext))
 
-    # print(config.option.doctestglob)
-    # exit(1)
+    # override default comment characters
+    ext_comment_pairs = [pair.split('=') for pair in config.getini('text_file_comment_chars')]
+    for ext, chars in ext_comment_pairs:
+        comment_characters[ext] = chars
 
     class DocTestModulePlus(doctest_plugin.DoctestModule):
         # pytest 2.4.0 defines "collect".  Prior to that, it defined

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -508,3 +508,29 @@ def test_text_file_comments(testdir):
         '--doctest-glob', '*.tex',
         '--doctest-glob', '*.txt'
     ).assertoutcome(passed=3)
+
+
+def test_text_file_comment_chars(testdir):
+    # override default comment chars
+    testdir.makeini(
+        """
+        [pytest]
+        text_file_extensions =
+            .rst=#
+            .tex=#
+    """
+    )
+    testdir.makefile(
+        '.rst',
+        foo_1="# >>> 1 + 1\n3",
+    )
+    testdir.makefile(
+        '.tex',
+        foo_2="# >>> 1 + 1\n3",
+    )
+    testdir.inline_run(
+        '--doctest-plus',
+        '--doctest-glob', '*.rst',
+        '--doctest-glob', '*.tex',
+        '--doctest-glob', '*.txt'
+    ).assertoutcome(passed=2)


### PR DESCRIPTION
close #9 
close #48

I marked `text-file-format` and `doctest-rst` as deprecated. But right now `doctest-glob` list is extended with `"*.{text_file_format}"` if `doctest_rst` is `True`. So `text-file-format` and `doctest-rst` will still work as expected.

Also comment chars are now determined by file extension instead of `text_file_format` and can be configured via ini variable `text_file_comment_chars`

```
[pytest]
text_file_comment_chars = 
    .rst=#
    .tex=#
```

default ones are still:

```
comment_characters = {
    '.txt': '#',
    '.tex': '%',
    '.rst': '..'
}
```