### PR TITLE
add doctest-only option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@
 
 - Allow to use doctest-glob option instead of doctest-rst and text-file-format [#9]
 
+- Add ``--doctest-only`` option. [#14]
+
 
 0.4.0 (2019-09-17)
 ==================

--- a/pytest_doctestplus/output_checker.py
+++ b/pytest_doctestplus/output_checker.py
@@ -18,6 +18,7 @@ from six.moves import zip
 
 FIX = doctest.register_optionflag('FIX')
 FLOAT_CMP = doctest.register_optionflag('FLOAT_CMP')
+REMOTE_DATA = doctest.register_optionflag('REMOTE_DATA')
 IGNORE_OUTPUT = doctest.register_optionflag('IGNORE_OUTPUT')
 IGNORE_OUTPUT_2 = doctest.register_optionflag('IGNORE_OUTPUT_2')
 IGNORE_OUTPUT_3 = doctest.register_optionflag('IGNORE_OUTPUT_3')
@@ -41,6 +42,8 @@ class OutputChecker(doctest.OutputChecker):
       string representation.  This naturally supports complex numbers as well
       (simply by comparing their real and imaginary parts separately).
     """
+    rtol = 1e-05
+    atol = 1e-08
 
     _original_output_checker = doctest.OutputChecker
 

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -9,20 +9,18 @@ import os
 import re
 import sys
 import warnings
-from distutils.version import LooseVersion
+
+import pytest
+import six
+
+from pytest_doctestplus.utils import ModuleChecker
+from .output_checker import FIX, IGNORE_WARNINGS, OutputChecker, REMOTE_DATA
 
 try:
     from textwrap import indent
 except ImportError:  # PY2
     def indent(text, prefix):
         return '\n'.join([prefix + line for line in text.splitlines()])
-
-import pytest
-import six
-
-from pytest_doctestplus.utils import ModuleChecker
-from .output_checker import FIX, IGNORE_WARNINGS, OutputChecker
-
 
 comment_characters = {
     '.txt': '#',
@@ -56,7 +54,6 @@ class _doctestplus_ignore_all_warnings(object):
 # these pytest hooks allow us to mark tests and run the marked tests with
 # specific command line options.
 def pytest_addoption(parser):
-
     parser.addoption("--doctest-plus", action="store_true",
                      help="enable running doctests with additional "
                           "features not found in the normal doctest "
@@ -84,6 +81,9 @@ def pytest_addoption(parser):
     parser.addoption("--doctest-plus-rtol", action="store",
                      help="set the relative tolerance for float comparison",
                      default=1e-05)
+
+    parser.addoption("--doctest-only", action="store_true",
+                     help="Test only doctests. Implies usage of doctest-plus.")
 
     parser.addini("text_file_format",
                   "Default format for docs. "
@@ -126,22 +126,20 @@ def get_optionflags(parent):
 
 
 def pytest_configure(config):
+    doctest_plugin = config.pluginmanager.getplugin('doctest')
+    run_regular_doctest = config.option.doctestmodules and not config.option.doctest_plus
+    use_doctest_plus = config.getini('doctest_plus') or config.option.doctest_plus or config.option.doctest_only
+    if doctest_plugin is None or run_regular_doctest or not use_doctest_plus:
+        return
+
     # We monkey-patch in our replacement doctest OutputChecker.  Not
     # great, but there isn't really an API to replace the checker when
     # using doctest.testfile, unfortunately.
+    doctest.OutputChecker = OutputChecker
     OutputChecker.rtol = max(float(config.getini("doctest_plus_rtol")),
                              float(config.getoption("doctest_plus_rtol")))
     OutputChecker.atol = max(float(config.getini("doctest_plus_atol")),
                              float(config.getoption("doctest_plus_atol")))
-    doctest.OutputChecker = OutputChecker
-
-    REMOTE_DATA = doctest.register_optionflag('REMOTE_DATA')
-
-    doctest_plugin = config.pluginmanager.getplugin('doctest')
-    run_regular_doctest = config.option.doctestmodules and not config.option.doctest_plus
-    if (doctest_plugin is None or run_regular_doctest or not
-            (config.getini('doctest_plus') or config.option.doctest_plus)):
-        return
 
     use_rst = config.getini('doctest_rst') or config.option.doctest_rst
     file_ext = config.option.text_file_format or config.getini('text_file_format') or 'rst'
@@ -211,7 +209,6 @@ def pytest_configure(config):
                         test.name, self, runner, test)
 
     class DocTestTextfilePlus(doctest_plugin.DoctestItem, pytest.Module):
-
         # Some pytest plugins such as hypothesis try and access the 'obj'
         # attribute, and by default this returns an error for this class
         # so we override it here to avoid any issues.
@@ -225,7 +222,7 @@ def pytest_configure(config):
 
             options = get_optionflags(self) | FIX
 
-            failed, tot = doctest.testfile(
+            doctest.testfile(
                 str(self.fspath), module_relative=False,
                 optionflags=options, parser=DocTestParserPlus(),
                 extraglobs=dict(getfixture=fixture_request.getfixturevalue),
@@ -335,12 +332,11 @@ def pytest_configure(config):
                                         + indent(entry.source, '    '))
                         ignore_warnings_context_needed = True
 
-                    if (skip_all or skip_next or
-                        not DocTestFinderPlus.check_required_modules(required)):
+                    has_required_modules = DocTestFinderPlus.check_required_modules(required)
+                    if skip_all or skip_next or not has_required_modules:
                         entry.options[doctest.SKIP] = True
 
-                    if (config.getoption('remote_data', 'none') != 'any' and
-                        entry.options.get(REMOTE_DATA)):
+                    if config.getoption('remote_data', 'none') != 'any' and entry.options.get(REMOTE_DATA):
                         entry.options[doctest.SKIP] = True
 
             # We insert the definition of the context manager to ignore
@@ -351,9 +347,13 @@ def pytest_configure(config):
             return result
 
     config.pluginmanager.register(
-        DoctestPlus(DocTestModulePlus, DocTestTextfilePlus,
-                    config.option.doctestglob),
-        'doctestplus')
+        DoctestPlus(
+            DocTestModulePlus,
+            DocTestTextfilePlus,
+            config.option.doctestglob,
+        ),
+        'doctestplus',
+    )
     # Remove the doctest_plugin, or we'll end up testing the .rst files twice.
     config.pluginmanager.unregister(doctest_plugin)
 
@@ -375,14 +375,21 @@ class DoctestPlus(object):
         self._ignore_paths = []
 
     def pytest_ignore_collect(self, path, config):
-        """Skip paths that match any of the doctest_norecursedirs patterns."""
-        collect_ignore = config._getconftest_pathlist("collect_ignore",
-                                                      path=path.dirpath())
+        """
+        Skip paths that match any of the doctest_norecursedirs patterns or
+        if doctest_only is True then skip all regular test files (eg test_*.py).
+        """
+        collect_ignore = config._getconftest_pathlist("collect_ignore", path=path.dirpath())
 
         # The collect_ignore conftest.py variable should cause all test
         # runners to ignore this file and all subfiles and subdirectories
         if collect_ignore is not None and path in collect_ignore:
             return True
+
+        if config.option.doctest_only:
+            for pattern in config.getini('python_files'):
+                if path.check(fnmatch=pattern):
+                    return True
 
         def get_list_opt(name):
             return getattr(config.option, name, None) or []
@@ -510,12 +517,9 @@ class DocTestFinderPlus(doctest.DocTestFinder):
                 return False
         return True
 
-    def find(self, obj, name=None, module=None, globs=None,
-             extraglobs=None):
-        tests = doctest.DocTestFinder.find(self, obj, name, module, globs,
-                                           extraglobs)
-        if (hasattr(obj, '__doctest_skip__') or
-                hasattr(obj, '__doctest_requires__')):
+    def find(self, obj, name=None, module=None, globs=None, extraglobs=None):
+        tests = doctest.DocTestFinder.find(self, obj, name, module, globs, extraglobs)
+        if hasattr(obj, '__doctest_skip__') or hasattr(obj, '__doctest_requires__'):
             if name is None and hasattr(obj, '__name__'):
                 name = obj.__name__
             else:
@@ -537,8 +541,7 @@ class DocTestFinderPlus(doctest.DocTestFinder):
                     if not isinstance(pats, tuple):
                         pats = (pats,)
                     for pat in pats:
-                        if not fnmatch.fnmatch(test.name,
-                                               '.'.join((name, pat))):
+                        if not fnmatch.fnmatch(test.name, '.'.join((name, pat))):
                             continue
                         if not self.check_required_modules(mods):
                             return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+from functools import partial
+import textwrap
+
+import pytest
+
+
+def _wrap_docstring_in_func(func_name, docstring):
+    template = textwrap.dedent(r"""
+        def {}():
+            r'''
+        {}
+            '''
+    """)
+    return template.format(func_name, docstring)
+
+
+@pytest.fixture
+def makepyfile(testdir):
+    """Fixture for making python files with single function and docstring."""
+    def make(*args, **kwargs):
+        func_name = kwargs.pop('func_name', 'f')
+        # content in args and kwargs is treated as docstring
+        wrap = partial(_wrap_docstring_in_func, func_name)
+        args = map(wrap, args)
+        kwargs = dict(zip(kwargs.keys(), map(wrap, kwargs.values())))
+        return testdir.makepyfile(*args, **kwargs)
+
+    return make
+
+
+@pytest.fixture
+def maketestfile(makepyfile):
+    """Fixture for making python test files with single function and docstring."""
+    def make(*args, **kwargs):
+        func_name = kwargs.pop('func_name', 'test_foo')
+        return makepyfile(*args, func_name=func_name, **kwargs)
+
+    return make
+
+
+@pytest.fixture
+def makerstfile(testdir):
+    """Fixture for making rst files with specified content."""
+    def make(*args, **kwargs):
+        return testdir.makefile('.rst', *args, **kwargs)
+
+    return make

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -596,3 +596,28 @@ if LooseVersion('4.3.0') <= LooseVersion(pytest.__version__):
         testdir.inline_run(
             '--doctest-plus', '--doctest-rst', '--ignore-glob', '*.rst'
         ).assertoutcome(passed=2)
+
+
+def test_doctest_only(testdir, makepyfile, maketestfile, makerstfile):
+    # regular python files with doctests
+    makepyfile(p1='>>> 1 + 1\n2')
+    makepyfile(p2='>>> 1 + 1\n3')
+    # regular test files
+    maketestfile(test_1='foo')
+    maketestfile(test_2='bar')
+    # rst files
+    makerstfile(r1='>>> 1 + 1\n2')
+    makerstfile(r3='>>> 1 + 1\n3')
+    makerstfile(r2='>>> 1 + 2\n3')
+
+    # regular tests
+    testdir.inline_run().assertoutcome(passed=2)
+    # regular + doctests
+    testdir.inline_run("--doctest-plus").assertoutcome(passed=3, failed=1)
+    # regular + doctests + doctest in rst files
+    testdir.inline_run("--doctest-plus", "--doctest-rst").assertoutcome(passed=5, failed=2)
+    # only doctests in python files, implicit usage of doctest-plus
+    testdir.inline_run("--doctest-only").assertoutcome(passed=1, failed=1)
+    # only doctests in python files
+    testdir.inline_run("--doctest-only", "--doctest-rst").assertoutcome(passed=3, failed=2)
+


### PR DESCRIPTION
close #14

### details

`--doctest-only` will implicitly use doctest-plus and will filter out all python test files (`python_files` in `pytest.ini`, eg `test_*.py`).

check out `test_doctest_only` for usage details https://github.com/astropy/pytest-doctestplus/blob/b1da7f4d0b4f4b6e2dc3423f42f715732a4cca80/tests/test_doctestplus.py#L395-L416
