### PR TITLE
New directive +IGNORE_WARNINGS to capture and silence warnings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,17 @@ This flag can be enabled globally by adding it to ``setup.cfg`` as in
         ELLIPSIS
         FLOAT_CMP
 
+Ignoring warnings
+~~~~~~~~~~~~~~~~~
+
+If code in a doctest emits a warning and you want to make sure that warning is silenced,
+you can make use of the ``IGNORE_WARNING`` flag. For example:
+
+.. code-block:: python
+
+  >>> import numpy as np
+  >>> np.mean([])  # doctest: +IGNORE_WARNING
+  np.nan
 
 Skipping Tests
 ~~~~~~~~~~~~~~
@@ -152,7 +163,7 @@ directive
 .. code-block:: rst
 
     .. doctest-skip::
-    
+
         >>> import asdf
         >>> asdf.open('file.asdf')
 
@@ -210,7 +221,7 @@ conditionally skipped if a dependency is not available.
 .. code-block:: rst
 
     .. doctest-requires:: asdf
-    
+
         >>> import asdf
         >>> asdf.open('file.asdf')
 
@@ -228,7 +239,7 @@ The following example illustrates how a doctest that uses remote data should be
 marked:
 
 .. code-block:: python
-    
+
     >>> from urlib.request import urlopen
     >>> url = urlopen('http://astropy.org') # doctest: +REMOTE_DATA
 

--- a/README.rst
+++ b/README.rst
@@ -139,12 +139,12 @@ Ignoring warnings
 ~~~~~~~~~~~~~~~~~
 
 If code in a doctest emits a warning and you want to make sure that warning is silenced,
-you can make use of the ``IGNORE_WARNING`` flag. For example:
+you can make use of the ``IGNORE_WARNINGS`` flag. For example:
 
 .. code-block:: python
 
   >>> import numpy as np
-  >>> np.mean([])  # doctest: +IGNORE_WARNING
+  >>> np.mean([])  # doctest: +IGNORE_WARNINGS
   np.nan
 
 Skipping Tests

--- a/pytest_doctestplus/output_checker.py
+++ b/pytest_doctestplus/output_checker.py
@@ -21,6 +21,7 @@ FLOAT_CMP = doctest.register_optionflag('FLOAT_CMP')
 IGNORE_OUTPUT = doctest.register_optionflag('IGNORE_OUTPUT')
 IGNORE_OUTPUT_2 = doctest.register_optionflag('IGNORE_OUTPUT_2')
 IGNORE_OUTPUT_3 = doctest.register_optionflag('IGNORE_OUTPUT_3')
+IGNORE_WARNING = doctest.register_optionflag('IGNORE_WARNING')
 
 # These might appear in some doctests and are used in the default pytest
 # doctest plugin. This plugin doesn't actually implement these flags but this

--- a/pytest_doctestplus/output_checker.py
+++ b/pytest_doctestplus/output_checker.py
@@ -21,7 +21,7 @@ FLOAT_CMP = doctest.register_optionflag('FLOAT_CMP')
 IGNORE_OUTPUT = doctest.register_optionflag('IGNORE_OUTPUT')
 IGNORE_OUTPUT_2 = doctest.register_optionflag('IGNORE_OUTPUT_2')
 IGNORE_OUTPUT_3 = doctest.register_optionflag('IGNORE_OUTPUT_3')
-IGNORE_WARNING = doctest.register_optionflag('IGNORE_WARNING')
+IGNORE_WARNINGS = doctest.register_optionflag('IGNORE_WARNINGS')
 
 # These might appear in some doctests and are used in the default pytest
 # doctest plugin. This plugin doesn't actually implement these flags but this

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -11,7 +11,12 @@ import os
 import re
 import sys
 import warnings
-from textwrap import indent
+
+try:
+    from textwrap import indent
+except ImportError:  # PY2
+    def indent(text, prefix):
+        return '\n'.join([prefix + line for line in text.splitlines()])
 
 import pytest
 

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -11,16 +11,39 @@ import os
 import re
 import sys
 import warnings
+from textwrap import indent
 
 import pytest
 
 from pytest_doctestplus.utils import ModuleChecker
-from .output_checker import OutputChecker, FIX
+from .output_checker import OutputChecker, FIX, IGNORE_WARNING
 
 comment_characters = {'txt': '#',
                       'tex': '%',
                       'rst': r'\.\.'
                       }
+
+
+# For the IGNORE_WARNING option, we create a context manager that doesn't
+# require us to add any imports to the example list and contains everything
+# that is needed to silence warnings.
+
+IGNORE_WARNING_CONTEXT = """
+class _doctestplus_ignore_all_warnings(object):
+
+    def __init__(self):
+        import warnings
+        self._cw = warnings.catch_warnings()
+
+    def __enter__(self, *args, **kwargs):
+        result = self._cw.__enter__(*args, **kwargs)
+        import warnings
+        warnings.simplefilter('ignore')
+        return result
+
+    def __exit__(self, *args, **kwargs):
+        return self._cw.__exit__(*args, **kwargs)
+""".lstrip()
 
 
 # these pytest hooks allow us to mark tests and run the marked tests with
@@ -135,9 +158,25 @@ def pytest_configure(config):
             for test in finder.find(module):
                 if test.examples:  # skip empty doctests
                     if config.getoption('remote_data', 'none') != 'any':
+
+                        ignore_warning_context_needed = False
+
                         for example in test.examples:
+
+                            # If warnings are to be ignored we need to catch them by
+                            # wrapping the source in a context manager.
+                            if example.options.get(IGNORE_WARNING, False):
+                                example.source = ("with _doctestplus_ignore_all_warnings():\n"
+                                                + indent(example.source, '    '))
+                                ignore_warning_context_needed = True
+
                             if example.options.get(REMOTE_DATA):
                                 example.options[doctest.SKIP] = True
+
+                        # We insert the definition of the context manager to ignore
+                        # warnings at the start of the file if needed.
+                        if ignore_warning_context_needed:
+                            test.examples.insert(0, doctest.Example(source=IGNORE_WARNING_CONTEXT, want=''))
 
                     yield doctest_plugin.DoctestItem(
                         test.name, self, runner, test)
@@ -213,7 +252,10 @@ def pytest_configure(config):
                               .format(file_format, comment_characters['rst']))
                 comment_char = comment_characters['rst']
 
+            ignore_warning_context_needed = False
+
             for entry in result:
+
                 if isinstance(entry, six.string_types) and entry:
                     required = []
                     skip_next = False
@@ -258,6 +300,14 @@ def pytest_configure(config):
                         # 'a a' or 'a,a' or 'a, a'-> [a, a]
                         required = re.split(r'\s*[,\s]\s*', match.group(1))
                 elif isinstance(entry, doctest.Example):
+
+                    # If warnings are to be ignored we need to catch them by
+                    # wrapping the source in a context manager.
+                    if entry.options.get(IGNORE_WARNING, False):
+                        entry.source = ("with _doctestplus_ignore_all_warnings():\n"
+                                        + indent(entry.source, '    '))
+                        ignore_warning_context_needed = True
+
                     if (skip_all or skip_next or
                         not DocTestFinderPlus.check_required_modules(required)):
                         entry.options[doctest.SKIP] = True
@@ -265,6 +315,11 @@ def pytest_configure(config):
                     if (config.getoption('remote_data', 'none') != 'any' and
                         entry.options.get(REMOTE_DATA)):
                         entry.options[doctest.SKIP] = True
+
+            # We insert the definition of the context manager to ignore
+            # warnings at the start of the file if needed.
+            if ignore_warning_context_needed:
+                result.insert(0, doctest.Example(source=IGNORE_WARNING_CONTEXT, want=''))
 
             return result
 

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -16,7 +16,7 @@ from textwrap import indent
 import pytest
 
 from pytest_doctestplus.utils import ModuleChecker
-from .output_checker import OutputChecker, FIX, IGNORE_WARNING
+from .output_checker import OutputChecker, FIX, IGNORE_WARNINGS
 
 comment_characters = {'txt': '#',
                       'tex': '%',
@@ -24,11 +24,11 @@ comment_characters = {'txt': '#',
                       }
 
 
-# For the IGNORE_WARNING option, we create a context manager that doesn't
+# For the IGNORE_WARNINGS option, we create a context manager that doesn't
 # require us to add any imports to the example list and contains everything
 # that is needed to silence warnings.
 
-IGNORE_WARNING_CONTEXT = """
+IGNORE_WARNINGS_CONTEXT = """
 class _doctestplus_ignore_all_warnings(object):
 
     def __init__(self):
@@ -159,24 +159,24 @@ def pytest_configure(config):
                 if test.examples:  # skip empty doctests
                     if config.getoption('remote_data', 'none') != 'any':
 
-                        ignore_warning_context_needed = False
+                        ignore_warnings_context_needed = False
 
                         for example in test.examples:
 
                             # If warnings are to be ignored we need to catch them by
                             # wrapping the source in a context manager.
-                            if example.options.get(IGNORE_WARNING, False):
+                            if example.options.get(IGNORE_WARNINGS, False):
                                 example.source = ("with _doctestplus_ignore_all_warnings():\n"
                                                 + indent(example.source, '    '))
-                                ignore_warning_context_needed = True
+                                ignore_warnings_context_needed = True
 
                             if example.options.get(REMOTE_DATA):
                                 example.options[doctest.SKIP] = True
 
                         # We insert the definition of the context manager to ignore
                         # warnings at the start of the file if needed.
-                        if ignore_warning_context_needed:
-                            test.examples.insert(0, doctest.Example(source=IGNORE_WARNING_CONTEXT, want=''))
+                        if ignore_warnings_context_needed:
+                            test.examples.insert(0, doctest.Example(source=IGNORE_WARNINGS_CONTEXT, want=''))
 
                     yield doctest_plugin.DoctestItem(
                         test.name, self, runner, test)
@@ -252,7 +252,7 @@ def pytest_configure(config):
                               .format(file_format, comment_characters['rst']))
                 comment_char = comment_characters['rst']
 
-            ignore_warning_context_needed = False
+            ignore_warnings_context_needed = False
 
             for entry in result:
 
@@ -303,10 +303,10 @@ def pytest_configure(config):
 
                     # If warnings are to be ignored we need to catch them by
                     # wrapping the source in a context manager.
-                    if entry.options.get(IGNORE_WARNING, False):
+                    if entry.options.get(IGNORE_WARNINGS, False):
                         entry.source = ("with _doctestplus_ignore_all_warnings():\n"
                                         + indent(entry.source, '    '))
-                        ignore_warning_context_needed = True
+                        ignore_warnings_context_needed = True
 
                     if (skip_all or skip_next or
                         not DocTestFinderPlus.check_required_modules(required)):
@@ -318,8 +318,8 @@ def pytest_configure(config):
 
             # We insert the definition of the context manager to ignore
             # warnings at the start of the file if needed.
-            if ignore_warning_context_needed:
-                result.insert(0, doctest.Example(source=IGNORE_WARNING_CONTEXT, want=''))
+            if ignore_warnings_context_needed:
+                result.insert(0, doctest.Example(source=IGNORE_WARNINGS_CONTEXT, want=''))
 
             return result
 

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -394,9 +394,9 @@ def test_requires(testdir):
     testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(passed=1)
 
 
-def test_ignore_warning_module(testdir):
+def test_ignore_warnings_module(testdir):
 
-    # First check that we get a warning if we don't add the IGNORE_WARNING
+    # First check that we get a warning if we don't add the IGNORE_WARNINGS
     # directive
     p = testdir.makepyfile(
         """
@@ -410,13 +410,13 @@ def test_ignore_warning_module(testdir):
     reprec = testdir.inline_run(p, "--doctest-plus", "-W error")
     reprec.assertoutcome(failed=1, passed=0)
 
-    # Now try with the IGNORE_WARNING directive
+    # Now try with the IGNORE_WARNINGS directive
     p = testdir.makepyfile(
         """
         def myfunc():
             '''
             >>> import warnings
-            >>> warnings.warn('A warning occurred', UserWarning)  # doctest: +IGNORE_WARNING
+            >>> warnings.warn('A warning occurred', UserWarning)  # doctest: +IGNORE_WARNINGS
             '''
             pass
         """)
@@ -424,9 +424,9 @@ def test_ignore_warning_module(testdir):
     reprec.assertoutcome(failed=0, passed=1)
 
 
-def test_ignore_warning_rst(testdir):
+def test_ignore_warnings_rst(testdir):
 
-    # First check that we get a warning if we don't add the IGNORE_WARNING
+    # First check that we get a warning if we don't add the IGNORE_WARNINGS
     # directive
     p = testdir.makefile(".rst",
         """
@@ -438,12 +438,12 @@ def test_ignore_warning_rst(testdir):
                                 "--text-file-format=rst", "-W error")
     reprec.assertoutcome(failed=1, passed=0)
 
-    # Now try with the IGNORE_WARNING directive
+    # Now try with the IGNORE_WARNINGS directive
     p = testdir.makefile(".rst",
         """
         ::
             >>> import warnings
-            >>> warnings.warn('A warning occurred', UserWarning)  # doctest: +IGNORE_WARNING
+            >>> warnings.warn('A warning occurred', UserWarning)  # doctest: +IGNORE_WARNINGS
         """)
     reprec = testdir.inline_run(p, "--doctest-plus", "--doctest-rst",
                                 "--text-file-format=rst", "-W error")

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -392,3 +392,59 @@ def test_requires(testdir):
     )
     # passed because 'pytest<1.0' was not satisfied and 'assert 0' was not evaluated
     testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(passed=1)
+
+
+def test_ignore_warning_module(testdir):
+
+    # First check that we get a warning if we don't add the IGNORE_WARNING
+    # directive
+    p = testdir.makepyfile(
+        """
+        def myfunc():
+            '''
+            >>> import warnings
+            >>> warnings.warn('A warning occurred', UserWarning)
+            '''
+            pass
+        """)
+    reprec = testdir.inline_run(p, "--doctest-plus", "-W error")
+    reprec.assertoutcome(failed=1, passed=0)
+
+    # Now try with the IGNORE_WARNING directive
+    p = testdir.makepyfile(
+        """
+        def myfunc():
+            '''
+            >>> import warnings
+            >>> warnings.warn('A warning occurred', UserWarning)  # doctest: +IGNORE_WARNING
+            '''
+            pass
+        """)
+    reprec = testdir.inline_run(p, "--doctest-plus", "-W error")
+    reprec.assertoutcome(failed=0, passed=1)
+
+
+def test_ignore_warning_rst(testdir):
+
+    # First check that we get a warning if we don't add the IGNORE_WARNING
+    # directive
+    p = testdir.makefile(".rst",
+        """
+        ::
+            >>> import warnings
+            >>> warnings.warn('A warning occurred', UserWarning)
+        """)
+    reprec = testdir.inline_run(p, "--doctest-plus", "--doctest-rst",
+                                "--text-file-format=rst", "-W error")
+    reprec.assertoutcome(failed=1, passed=0)
+
+    # Now try with the IGNORE_WARNING directive
+    p = testdir.makefile(".rst",
+        """
+        ::
+            >>> import warnings
+            >>> warnings.warn('A warning occurred', UserWarning)  # doctest: +IGNORE_WARNING
+        """)
+    reprec = testdir.inline_run(p, "--doctest-plus", "--doctest-rst",
+                                "--text-file-format=rst", "-W error")
+    reprec.assertoutcome(failed=0, passed=1)


### PR DESCRIPTION
There are cases where lines in a doctest will emit a warning but we don't necessarily want to show it in the output or have the warning end up being counted by pytest. This new directive will make sure all warnings on that line will be silenced.

@vanyakosmos - feel free to review this if you'd like, since you are very familiar with this plugin! :)

@pllim - you might also be interested in this :)