### PR TITLE
Adding pip as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'Topic :: Utilities',
     ],
     keywords=['doctest', 'rst', 'pytest', 'py.test'],
-    install_requires=['six', 'pytest>=3.0'],
+    install_requires=['six', 'pytest>=3.0', 'pip'],
     python_requires='>=2.7',
     entry_points={
         'pytest11': [


### PR DESCRIPTION
Is this what you had in mind @olebole for #89?
(I haven't found a precedent for it in any of the packages I looked into. The closest was  setuptools, but even there pip and wheel is just an optional dependency and thus not listed in the setup files).