### PR TITLE
TST: Bump latest Python version to 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
           env: PYTHON_VERSION=3.7
 
         # Try a run against latest pytest
-        - env: PYTHON_VERSION=3.7 PYTEST_VERSION=5
+        - env: PYTHON_VERSION=3.8 PYTEST_VERSION=5
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git


### PR DESCRIPTION
~For some reason, `pytest` 5.0 is being picked up, not 5.4.x, so this PR pins it to 5.4.1. This is not ideal as someone needs to remember to bump it time and again. This is not needed if a fix can be made upstream at `ci-helpers`.~ (Turns out `ci-helpers` picking up 5.3 from `conda` and only falls back to PyPI when `conda` fails.)

**EDIT:** Now only bumps accompanying Python to 3.8. (Why not?)