### PR TITLE
Jail doctestplus outputs in tmpdir

### DIFF
--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -51,6 +51,23 @@ class _doctestplus_ignore_all_warnings(object):
 """.lstrip()
 
 
+@pytest.fixture(autouse=True)
+def _docdir(request):
+    """Run doctests in isolated tmpdir so outputs do not end up in repo"""
+    # Trigger ONLY for doctestplus
+    doctest_plugin = request.config.pluginmanager.getplugin("doctestplus")
+    if isinstance(request.node, doctest_plugin._doctest_textfile_item_cls):
+        # Don't apply this fixture to io.rst.  It reads files and doesn't write
+        if "io.rst" not in request.node.name:
+            tmpdir = request.getfixturevalue('tmpdir')
+            with tmpdir.as_cwd():
+                yield
+        else:
+            yield
+    else:
+        yield
+
+
 # these pytest hooks allow us to mark tests and run the marked tests with
 # specific command line options.
 def pytest_addoption(parser):

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -55,8 +55,8 @@ class _doctestplus_ignore_all_warnings(object):
 def _docdir(request):
     """Run doctests in isolated tmpdir so outputs do not end up in repo"""
     # Trigger ONLY for doctestplus
-    doctest_plugin = request.config.pluginmanager.getplugin("doctestplus")
-    if isinstance(request.node, doctest_plugin._doctest_textfile_item_cls):
+    doctest_plugin = request.config.pluginmanager.getplugin("pytest_doctestplus")
+    if isinstance(request.node, doctest_plugin.DocTestTextfilePlus):
         # Don't apply this fixture to io.rst.  It reads files and doesn't write
         if "io.rst" not in request.node.name:
             tmpdir = request.getfixturevalue('tmpdir')


### PR DESCRIPTION
This was originally implemented by @jdavies-st as astropy/astropy#9439 but was decided that this should move here instead.

Fix #68 

xref astropy/astropy#10037

**TODO**

- [ ] Does this need a change log?
- [ ] How do we test this? Does this really work?