### PR TITLE
Travis cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,6 @@ os:
     - linux
     - windows
 
-stage: All tests
-
-# Use Travis' container-based architecture
-sudo: false
-
 env:
     global:
         # The following versions are the 'default' for tests, unless
@@ -22,7 +17,7 @@ env:
         - PYTEST_COMMAND='pytest'
         - CONDA_DEPENDENCIES='six'
 
-    matrix:
+    jobs:
         - PYTHON_VERSION=2.7 PYTEST_COMMAND='py.test'
         - PYTHON_VERSION=3.5 NUMPY_VERSION=1.15
         - PYTHON_VERSION=3.6
@@ -34,7 +29,7 @@ stages:
     - name: Initial tests
     - name: All tests
 
-matrix:
+jobs:
     include:
         - os: linux
           env: PYTHON_VERSION=3.7 NUMPY_VERSION=stable
@@ -46,10 +41,13 @@ matrix:
 
         # Try a run on OSX with latest versions of python and pytest
         - os: osx
+          stage: All tests
           env: PYTHON_VERSION=3.7
 
         # Try a run against latest pytest
-        - env: PYTHON_VERSION=3.7 PYTEST_VERSION=5
+        - os: linux
+          stage: All tests
+          env: PYTHON_VERSION=3.7 PYTEST_VERSION=5
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
         - PYTEST_VERSION=4
         - PYTEST_COMMAND='pytest'
         - CONDA_DEPENDENCIES='six'
+        - DEBUG=True
 
     jobs:
         - PYTHON_VERSION=2.7 PYTEST_COMMAND='py.test'


### PR DESCRIPTION
The point here is to add debug that I can use to see what goes wrong with PYTEST_VERSION=5 and ci-helpers. Maybe nothing, as I see 5.3.8 versions being installed 🤷‍♀ 