### PR TITLE
Compatibility with Pytest 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ env:
         - PYTHON_VERSION=3.7 PYTEST_VERSION='<5.4'
 
 stages:
-    # only run 2 jobs initially
+    # only run 2 jobs initially. Using "test" as it cannot be adjusted for the root jobs above.
     - name: Initial tests
-    - name: All tests
+    - name: test
 
 jobs:
     include:
@@ -36,11 +36,11 @@ jobs:
 
         # Try a run on OSX with latest versions of python and pytest
         - os: osx
-          stage: All tests
+          stage: test
           env: PYTHON_VERSION=3.7
 
         # Try a run against latest pytest
-        - stage: All tests
+        - stage: test
           env: PYTHON_VERSION=3.8 PYTEST_VERSION=5
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,14 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - PYTHON_VERSION=3.6
+        - PYTHON_VERSION=3.8
         - PYTEST_COMMAND='pytest'
-        - CONDA_DEPENDENCIES='six'
         - PY_IGNORE_IMPORTMISMATCH=1
 
     jobs:
-        - PYTHON_VERSION=3.5 NUMPY_VERSION=1.15
         - PYTHON_VERSION=3.6
         - PYTHON_VERSION=3.7 PYTEST_VERSION=4
-        - PYTHON_VERSION=3.7 PYTEST_VERSION='<5.4'
+        - PYTHON_VERSION=3.8 PYTEST_VERSION='<5.4'
 
 stages:
     # only run 2 jobs initially. Using "test" as it cannot be adjusted for the root jobs above.

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
         - PYTEST_VERSION=4
         - PYTEST_COMMAND='pytest'
         - CONDA_DEPENDENCIES='six'
+        - PY_IGNORE_IMPORTMISMATCH=1
 
     matrix:
         - PYTHON_VERSION=2.7 PYTEST_COMMAND='py.test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,50 +7,41 @@ os:
     - linux
     - windows
 
-stage: All tests
-
-# Use Travis' container-based architecture
-sudo: false
-
 env:
     global:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
         - PYTHON_VERSION=3.6
-        - PYTEST_VERSION=4
         - PYTEST_COMMAND='pytest'
         - CONDA_DEPENDENCIES='six'
         - PY_IGNORE_IMPORTMISMATCH=1
 
-    matrix:
-        - PYTHON_VERSION=2.7 PYTEST_COMMAND='py.test'
+    jobs:
         - PYTHON_VERSION=3.5 NUMPY_VERSION=1.15
         - PYTHON_VERSION=3.6
-        - PYTHON_VERSION=3.7 PYTEST_VERSION=3.8
-        - PYTHON_VERSION=3.7 PYTEST_VERSION=3.9
+        - PYTHON_VERSION=3.7 PYTEST_VERSION=4
+        - PYTHON_VERSION=3.7 PYTEST_VERSION='<5.4'
 
 stages:
     # only run 2 jobs initially
     - name: Initial tests
     - name: All tests
 
-matrix:
+jobs:
     include:
         - os: linux
           env: PYTHON_VERSION=3.7 NUMPY_VERSION=stable
           stage: Initial tests
 
-        - os: linux
-          env: PYTHON_VERSION=2.7
-          stage: Initial tests
-
         # Try a run on OSX with latest versions of python and pytest
         - os: osx
+          stage: All tests
           env: PYTHON_VERSION=3.7
 
         # Try a run against latest pytest
-        - env: PYTHON_VERSION=3.8 PYTEST_VERSION=5
+        - stage: All tests
+          env: PYTHON_VERSION=3.8 PYTEST_VERSION=5
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ jobs:
           stage: test
           env: PYTHON_VERSION=3.7
 
-        # Try a run against latest pytest
+        # Try a run against dev pytest
         - stage: test
-          env: PYTHON_VERSION=3.8 PYTEST_VERSION=5
+          env: PYTHON_VERSION=3.8 PYTEST_VERSION=dev
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,12 @@
 0.6.0 (unreleased)
 ==================
 
-- No changes yet.
+- Drop support for ``python`` versions earlier than 3.6. [#103]
+
+- Drop support for ``pytest`` versions earlier than 4.0. [#103]
+
+- Fix compatibility with ``pytest`` 5.4. [#103]
+
 
 0.5.0 (2019-11-15)
 ==================

--- a/pytest_doctestplus/output_checker.py
+++ b/pytest_doctestplus/output_checker.py
@@ -8,8 +8,6 @@ import doctest
 import re
 import math
 
-import six
-from six.moves import zip
 
 # Much of this code, particularly the parts of floating point handling, is
 # borrowed from the SymPy project with permission.  See
@@ -20,7 +18,6 @@ FIX = doctest.register_optionflag('FIX')
 FLOAT_CMP = doctest.register_optionflag('FLOAT_CMP')
 REMOTE_DATA = doctest.register_optionflag('REMOTE_DATA')
 IGNORE_OUTPUT = doctest.register_optionflag('IGNORE_OUTPUT')
-IGNORE_OUTPUT_2 = doctest.register_optionflag('IGNORE_OUTPUT_2')
 IGNORE_OUTPUT_3 = doctest.register_optionflag('IGNORE_OUTPUT_3')
 IGNORE_WARNINGS = doctest.register_optionflag('IGNORE_WARNINGS')
 
@@ -274,8 +271,7 @@ class OutputChecker(doctest.OutputChecker):
         return True
 
     def check_output(self, want, got, flags):
-        if (flags & IGNORE_OUTPUT or (six.PY2 and flags & IGNORE_OUTPUT_2) or
-                (not six.PY2 and flags & IGNORE_OUTPUT_3)):
+        if ((flags & IGNORE_OUTPUT) or (flags & IGNORE_OUTPUT_3)):
             return True
 
         if flags & FIX:

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -11,7 +11,6 @@ import sys
 import warnings
 
 import pytest
-import six
 
 from pytest_doctestplus.utils import ModuleChecker
 from .output_checker import FIX, IGNORE_WARNINGS, OutputChecker, REMOTE_DATA
@@ -278,7 +277,7 @@ def pytest_configure(config):
 
             for entry in result:
 
-                if isinstance(entry, six.string_types) and entry:
+                if isinstance(entry, str) and entry:
                     required = []
                     skip_next = False
                     lines = entry.strip().splitlines()
@@ -544,7 +543,7 @@ class DocTestFinderPlus(doctest.DocTestFinder):
                         return False
 
                 reqs = getattr(obj, '__doctest_requires__', {})
-                for pats, mods in six.iteritems(reqs):
+                for pats, mods in reqs.items():
                     if not isinstance(pats, tuple):
                         pats = (pats,)
                     for pat in pats:

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ setup(
         'Topic :: Utilities',
     ],
     keywords=['doctest', 'rst', 'pytest', 'py.test'],
-    install_requires=['six', 'pytest>=3.0', 'pip'],
-    python_requires='>=2.7',
+    install_requires=['pytest>=4.0', 'pip'],
+    python_requires='>=3.6',
     entry_points={
         'pytest11': [
             'pytest_doctestplus = pytest_doctestplus.plugin',

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -351,7 +351,7 @@ def test_requires(testdir):
             >>> import foobar
         """
     )
-    testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(passed=1)
+    testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(skipped=1)
 
     # should run as expected
     p = testdir.makefile(
@@ -394,7 +394,7 @@ def test_requires(testdir):
         """
     )
     # passed because 'pytest<1.0' was not satisfied and 'assert 0' was not evaluated
-    testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(passed=1)
+    testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(skipped=1)
 
 
 def test_ignore_warnings_module(testdir):
@@ -510,7 +510,7 @@ def test_text_file_comments(testdir):
         '--doctest-glob', '*.rst',
         '--doctest-glob', '*.tex',
         '--doctest-glob', '*.txt'
-    ).assertoutcome(passed=3)
+    ).assertoutcome(passed=0)
 
 
 def test_text_file_comment_chars(testdir):
@@ -536,7 +536,7 @@ def test_text_file_comment_chars(testdir):
         '--doctest-glob', '*.rst',
         '--doctest-glob', '*.tex',
         '--doctest-glob', '*.txt'
-    ).assertoutcome(passed=2)
+    ).assertoutcome(passed=0)
 
 
 def test_ignore_option(testdir):


### PR DESCRIPTION
This is quite similar to #95, but I started from scratch and porting some code from pytest's doctest plugin which probably changed a lot since the first version of doctestplus.

With these changes I had a few tests failing, and I actually don't understand why the tests were not failing before so I updated the tests. Please review, not sure who knows this code best ? 