### PR TITLE
Skip doctest collection in subpackages based on requirements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,8 @@
 0.7.0 (unreleased)
 ==================
 
-- No changes yet
-
+- Added a new ini option, ``doctest_subpackage_requires``, that can be used to skip
+  specific subpackages based on required packages. [#112]
 
 0.6.1 (2020-05-04)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -226,13 +226,13 @@ conditionally skipped if a dependency is not available.
         >>> asdf.open('file.asdf')
 
 Finally, it is possible to skip collecting doctests in entire subpackages by
-using the ``doctest_subpackage_requires`` option in ``pytest.ini`` or
-``setup.cfg``. The syntax for this option is a list of ``path:requirements``,
-e.g.::
+using the ``doctest_subpackage_requires`` in the ``[tool:pytest]`` section of
+the package's ``setup.cfg`` file. The syntax for this option is a list of
+``path:requirements``, e.g.::
 
     doctest_subpackage_requires =
-        astropy/wcs/*:scipy>2.0;numpy>1.14
-        astropy/cosmology/*:scipy>1.0
+        astropy/wcs/*=scipy>2.0;numpy>1.14
+        astropy/cosmology/*=scipy>1.0
 
 Multiple requirements can be specified if separated by semicolons.
 

--- a/README.rst
+++ b/README.rst
@@ -225,6 +225,17 @@ conditionally skipped if a dependency is not available.
         >>> import asdf
         >>> asdf.open('file.asdf')
 
+Finally, it is possible to skip collecting doctests in entire subpackages by
+using the ``doctest_subpackage_requires`` option in ``pytest.ini`` or
+``setup.cfg``. The syntax for this option is a list of ``path:requirements``,
+e.g.::
+
+    doctest_subpackage_requires =
+        astropy/wcs/*:scipy>2.0;numpy>1.14
+        astropy/cosmology/*:scipy>1.0
+
+Multiple requirements can be specified if separated by semicolons.
+
 Remote Data
 ~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -228,11 +228,11 @@ conditionally skipped if a dependency is not available.
 Finally, it is possible to skip collecting doctests in entire subpackages by
 using the ``doctest_subpackage_requires`` in the ``[tool:pytest]`` section of
 the package's ``setup.cfg`` file. The syntax for this option is a list of
-``path:requirements``, e.g.::
+``path = requirements``, e.g.::
 
     doctest_subpackage_requires =
-        astropy/wcs/*=scipy>2.0;numpy>1.14
-        astropy/cosmology/*=scipy>1.0
+        astropy/wcs/* = scipy>2.0;numpy>1.14
+        astropy/cosmology/* = scipy>1.0
 
 Multiple requirements can be specified if separated by semicolons.
 

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -416,8 +416,8 @@ class DoctestPlus(object):
 
         for option in config.getini("doctest_subpackage_requires"):
             subpackage_pattern, required = option.split('=', 1)
-            if path.check(fnmatch=subpackage_pattern):
-                required = required.split(';')
+            if path.check(fnmatch=subpackage_pattern.strip()):
+                required = required.strip().split(';')
                 if not DocTestFinderPlus.check_required_modules(required):
                     self._ignore_paths.append(path)
                     break

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -117,7 +117,7 @@ def pytest_addoption(parser):
 
     parser.addini("doctest_subpackage_requires",
                   "A list of paths to skip if requirements are not satisfied. Each item in the list "
-                  "should have the syntax path=req1;req2.",
+                  "should have the syntax path=req1;req2",
                   type='linelist',
                   default=[])
 

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -117,7 +117,7 @@ def pytest_addoption(parser):
 
     parser.addini("doctest_subpackage_requires",
                   "A list of paths to skip if requirements are not satisfied. Each item in the list "
-                  "should have the syntax path:req1;req2.",
+                  "should have the syntax path=req1;req2.",
                   type='linelist',
                   default=[])
 

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -115,6 +115,12 @@ def pytest_addoption(parser):
                   type='linelist',
                   default=[])
 
+    parser.addini("doctest_subpackage_requires",
+                  "A list of paths to skip if requirements are not satisfied. Each item in the list "
+                  "should have the syntax path:req1;req2.",
+                  type='linelist',
+                  default=[])
+
 
 def get_optionflags(parent):
     optionflags_str = parent.config.getini('doctest_optionflags')
@@ -168,12 +174,10 @@ def pytest_configure(config):
                 try:
                     module = self.fspath.pyimport()
                 except ImportError:
-                    pytest.skip("unable to import module %r" % self.fspath)
-                    # NOT USED: While correct, this breaks existing behavior.
-                    # if self.config.getvalue("doctest_ignore_import_errors"):
-                    #     pytest.skip("unable to import module %r" % self.fspath)
-                    # else:
-                    #     raise
+                    if self.config.getvalue("doctest_ignore_import_errors"):
+                        pytest.skip("unable to import module %r" % self.fspath)
+                    else:
+                        raise
 
             options = get_optionflags(self) | FIX
 
@@ -409,6 +413,14 @@ class DoctestPlus(object):
                 # avoid creating doctest nodes for them
                 self._ignore_paths.append(path)
                 break
+
+        for option in config.getini("doctest_subpackage_requires"):
+            subpackage_pattern, required = option.split(':', 1)
+            if path.check(fnmatch=subpackage_pattern):
+                required = required.split(';')
+                if not DocTestFinderPlus.check_required_modules(required):
+                    self._ignore_paths.append(path)
+                    break
 
         return False
 

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -415,7 +415,7 @@ class DoctestPlus(object):
                 break
 
         for option in config.getini("doctest_subpackage_requires"):
-            subpackage_pattern, required = option.split(':', 1)
+            subpackage_pattern, required = option.split('=', 1)
             if path.check(fnmatch=subpackage_pattern):
                 required = required.split(';')
                 if not DocTestFinderPlus.check_required_modules(required):

--- a/pytest_doctestplus/utils.py
+++ b/pytest_doctestplus/utils.py
@@ -78,7 +78,6 @@ class ModuleChecker:
         try:
             return self._find_distribution(dist)
         except Exception as e:
-            logger.warning(e)
             return None
 
     def check(self, module):

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -658,9 +658,9 @@ def test_doctest_subpackage_requires(testdir):
         """
         [pytest]
         doctest_subpackage_requires =
-            test/a/*:pytest>1
-            test/b/*:pytest>1;averyfakepackage>99999.9
-            test/c/*:anotherfakepackage>=22000.1.2
+            test/a/*=pytest>1
+            test/b/*=pytest>1;averyfakepackage>99999.9
+            test/c/*=anotherfakepackage>=22000.1.2
     """
     )
     test = testdir.mkdir('test')

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -651,3 +651,35 @@ def test_doctest_float_replacement(tmpdir):
 
     doctest.testfile(str(test2_rst), module_relative=False,
                      raise_on_error=True, verbose=False, encoding='utf-8')
+
+
+def test_doctest_subpackage_requires(testdir):
+    testdir.makeini(
+        """
+        [pytest]
+        doctest_subpackage_requires =
+            test/a/*:pytest>1
+            test/b/*:pytest>1;averyfakepackage>99999.9
+            test/c/*:anotherfakepackage>=22000.1.2
+    """
+    )
+    test = testdir.mkdir('test')
+    a = test.mkdir('a')
+    b = test.mkdir('b')
+    c = test.mkdir('c')
+
+    pyfile = dedent("""
+        def f():
+            '''
+            >>> 1
+            1
+            '''
+            pass
+    """)
+
+    a.join('testcode.py').write(pyfile)
+    b.join('testcode.py').write(pyfile)
+    c.join('testcode.py').write(pyfile)
+
+    reprec = testdir.inline_run(test, "--doctest-plus")
+    reprec.assertoutcome(passed=1)

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -655,12 +655,16 @@ def test_doctest_float_replacement(tmpdir):
 
 
 def test_doctest_subpackage_requires(testdir, caplog):
+
+    # Note that each entry below has different whitespace around the = to
+    # make sure that all cases work properly.
+
     testdir.makeini(
         """
         [pytest]
         doctest_subpackage_requires =
             test/a/* = pytest>1
-            test/b/*=pytest>1;averyfakepackage>99999.9
+            test/b/*= pytest>1;averyfakepackage>99999.9
             test/c/*=anotherfakepackage>=22000.1.2
     """
     )

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -659,7 +659,7 @@ def test_doctest_subpackage_requires(testdir, caplog):
         """
         [pytest]
         doctest_subpackage_requires =
-            test/a/*=pytest>1
+            test/a/* = pytest>1
             test/b/*=pytest>1;averyfakepackage>99999.9
             test/c/*=anotherfakepackage>=22000.1.2
     """

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -1,3 +1,4 @@
+import os
 from distutils.version import LooseVersion
 from textwrap import dedent
 
@@ -653,7 +654,7 @@ def test_doctest_float_replacement(tmpdir):
                      raise_on_error=True, verbose=False, encoding='utf-8')
 
 
-def test_doctest_subpackage_requires(testdir):
+def test_doctest_subpackage_requires(testdir, caplog):
     testdir.makeini(
         """
         [pytest]
@@ -683,3 +684,5 @@ def test_doctest_subpackage_requires(testdir):
 
     reprec = testdir.inline_run(test, "--doctest-plus")
     reprec.assertoutcome(passed=1)
+    assert reprec.listoutcomes()[0][0].location[0] == os.path.join('test', 'a', 'testcode.py')
+    assert caplog.text == ''


### PR DESCRIPTION
This implements an idea related to those in https://github.com/astropy/pytest-doctestplus/issues/110, namely that we can skip collecting doctests in specific sub-packages by specifying paths and requirements in the ``setup.cfg`` file, e.g.:

```
    doctest_subpackage_requires =
        astropy/wcs/*:scipy>2.0;numpy>1.14
        astropy/cosmology/*:scipy>1.0
```

This ended up being cleaner than using e.g. ``__doctest_subpackage_requires__`` in e.g. ``__init__.py`` files since these would need to be parsed with e.g. ast and not imported and so on.

Note that for skipping ``setup_package.py`` files there is already a solution which is to specify:

```
doctest_norecursedirs =
    */setup_package.py
```

in ``setup.cfg`` files and it works nicely.

Note that this then adds back the default behavior of failing on import errors since there is now a way to work around those.

EDIT: Fix #110 