### PR TITLE
Add the doctestplus sphinx extension

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -250,6 +250,17 @@ statements marked with ``--remote-data`` will be skipped.
 .. _pytest-remotedata: https://github.com/astropy/pytest-remotedata
 __ pytest-remotedata_
 
+Sphinx Compatibility
+~~~~~~~~~~~~~~~~~~~~
+
+To use the additional directives when building your documentation with sphinx
+you may want to enable the sphinx extension which registers these directives
+with sphinx. Doing so ensures that sphinx correctly ignores these directives,
+running the doctests with sphinx is not supported. To do this, add
+``'pytest_doctestplus.sphinx.doctestplus'`` to your ``extensions`` list in your
+``conf.py`` file.
+
+
 Development Status
 ------------------
 

--- a/pytest_doctestplus/sphinx/doctestplus.py
+++ b/pytest_doctestplus/sphinx/doctestplus.py
@@ -1,0 +1,56 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+This is a set of three directives that allow us to insert metadata
+about doctests into the .rst files so the testing framework knows
+which tests to skip.
+
+This is quite different from the doctest extension in Sphinx itself,
+which actually does something.  For astropy, all of the testing is
+centrally managed from py.test and Sphinx is not used for running
+tests.
+"""
+import re
+from docutils.nodes import literal_block
+from docutils.parsers.rst import Directive
+
+
+class DoctestSkipDirective(Directive):
+    has_content = True
+
+    def run(self):
+        # Check if there is any valid argument, and skip it. Currently only
+        # 'win32' is supported in astropy.tests.pytest_plugins.
+        if re.match('win32', self.content[0]):
+            self.content = self.content[2:]
+        code = '\n'.join(self.content)
+        return [literal_block(code, code)]
+
+
+class DoctestOmitDirective(Directive):
+    has_content = True
+
+    def run(self):
+        # Simply do not add any content when this directive is encountered
+        return []
+
+
+class DoctestRequiresDirective(DoctestSkipDirective):
+    # This is silly, but we really support an unbounded number of
+    # optional arguments
+    optional_arguments = 64
+
+
+def setup(app):
+
+    app.add_directive('doctest-requires', DoctestRequiresDirective)
+    app.add_directive('doctest-skip', DoctestSkipDirective)
+    app.add_directive('doctest-skip-all', DoctestSkipDirective)
+    app.add_directive('doctest', DoctestSkipDirective, override=True)
+    # Code blocks that use this directive will not appear in the generated
+    # documentation. This is intended to hide boilerplate code that is only
+    # useful for testing documentation using doctest, but does not actually
+    # belong in the documentation itself.
+    app.add_directive('testsetup', DoctestOmitDirective, override=True)
+
+    return {'parallel_read_safe': True,
+            'parallel_write_safe': True}


### PR DESCRIPTION
I could see no good reason why this extension was in `sphinx-astropy` rather than `pytest_doctestplus` if all it is doing is telling sphinx to ignore the doctestplus metadata?

I made one small modification to this, which is to set the `override=True` flag on the two directives which are also defined in the sphinx doctest extension, this prevents any warnings being raised when parsing the conf.py file.