### PR TITLE
list setuptools as a runtime dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.9.0 (unreleased)
 ==================
 
+- Declare ``setuptools`` runtime dependency [#93]
+
 0.8.0 (2020-07-31)
 ==================
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     pytest>=4.6
+    setuptools>=30.3.0
 
 [options.entry_points]
 pytest11 =


### PR DESCRIPTION
We use pkg_resources, which is provided by setuptools, in utils.py.
This will resolve issues in those rare cases where you can install
pytest-doctestplus without having setuptools present, such as when
using conda-forge.

Closes #93