### PR TITLE
Remove old code (Python 3.4) in ModuleChecker

### DIFF
--- a/pytest_doctestplus/utils.py
+++ b/pytest_doctestplus/utils.py
@@ -4,22 +4,19 @@ import pkg_resources
 
 
 class ModuleChecker:
-    def __init__(self):
-        self._find_module = importlib.util.find_spec
-        self._find_distribution = pkg_resources.require
 
     def find_module(self, module):
         """Search for modules specification."""
         try:
-            return self._find_module(module)
+            return importlib.util.find_spec(module)
         except ImportError:
             return None
 
     def find_distribution(self, dist):
         """Search for distribution with specified version (eg 'numpy>=1.15')."""
         try:
-            return self._find_distribution(dist)
-        except Exception as e:
+            return pkg_resources.require(dist)
+        except Exception:
             return None
 
     def check(self, module):

--- a/pytest_doctestplus/utils.py
+++ b/pytest_doctestplus/utils.py
@@ -1,69 +1,12 @@
 import importlib.util
-import json
-import logging
-import operator
-import re
-import subprocess
-import sys
-from packaging.version import Version
 
 import pkg_resources
-
-logger = logging.getLogger(__name__)
 
 
 class ModuleChecker:
     def __init__(self):
         self._find_module = importlib.util.find_spec
         self._find_distribution = pkg_resources.require
-        self.packages = {}
-
-    def get_packages(self):
-        packages = subprocess.check_output(
-            [sys.executable, '-m', 'pip', 'list', '--format', 'json']
-        ).decode()
-        packages = {item['name'].lower(): item['version']
-                    for item in json.loads(packages)}
-        return packages
-
-    def compare_versions(self, v1, v2, op):
-        op_map = {
-            '<': operator.lt,
-            '<=': operator.le,
-            '>': operator.gt,
-            '>=': operator.ge,
-            '==': operator.eq,
-        }
-        if op not in op_map:
-            return False
-        op = op_map[op]
-        return op(Version(v1), Version(v2))
-
-    def _check_distribution(self, module):
-        """
-        Python 2 (and <3.4) compatible version of pkg_resources.require.
-        But unlike pkg_resources.require it just checks whether package is
-        installed and has required version.
-        """
-        match = re.match(r'([A-Za-z0-9-_]+)([^A-Za-z0-9-_]+)([\d.]+$)', module)
-        if not match:
-            return False
-        package, cmp, version = match.groups()
-        package = package.lower()
-
-        if package in self.packages:
-            installed_version = self.packages[package]
-            if self.compare_versions(installed_version, version, cmp):
-                return True
-            else:
-                logger.warning(
-                    "{} {} is installed. Version {}{} is required".format(
-                        package, installed_version, cmp, version
-                    )
-                )
-                return False
-        logger.warning("The '{}' distribution was not found and is required by the application".format(package))
-        return False
 
     def find_module(self, module):
         """Search for modules specification."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,15 +11,3 @@ class TestModuleChecker:
         c = ModuleChecker()
         assert c.check('pytest>1.0')
         assert not c.check('foobar>1.0')
-
-    def test_check_distribution(self):
-        c = ModuleChecker()
-        # in python3.4+ packages attribute will not be populated
-        # because it calls 'pip freeze' which is slow
-        if not c.packages:
-            c.packages = c.get_packages()
-            # after this we will be able to test _check_distribution even in
-            # python3.4+ environment
-        assert c._check_distribution('pytest>1.0')
-        assert not c._check_distribution('pytest<1.0')
-        assert not c._check_distribution('foobar>1.0')


### PR DESCRIPTION
While removing Python < 3.4 compatibility in 410efdc685551fd4667e9d1a830ff40e7da203e8, I missed that several methods were needed only for Python < 3.4 and are hence no more needed.

For reference, this code was added in d7e81f525597b80897b367d395e5c668c5f8e1b8

I think we could rework this code using [packaging](https://packaging.pypa.io/en/latest/requirements/) and [importlib.metadata](https://docs.python.org/3/library/importlib.metadata.html), to remove the `pkg_resources` dependency. Maybe later.