### PR TITLE
ENH: Support remote data in doctest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,8 @@ venv
 # PyCharm
 .idea
 
+# VS code
+.vscode
+
 pytest_doctestplus/version.py
 pip-wheel-metadata/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "restructuredtext.confPath": ""
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "restructuredtext.confPath": ""
-}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 0.10.0 (unreleased)
 ===================
 
+- Added ``..doctest-remote-data::`` directive to control remote data
+  access for a chunk of code. [#137]
+
 - Drop support for ``python`` 3.6. [#159]
 
 - Fixed a bug where the command-line option ``--remote-data=any`` (associated
@@ -10,11 +13,9 @@
 - Fix wrong behavior with ``IGNORE_WARNINGS`` and ``SHOW_WARNINGS`` that could
   make a block to pass instead of being skipped. [#148]
 
+
 0.9.0 (2021-01-14)
 ==================
-
-- Added ``..doctest-remote-data::`` directive to control remote data 
-  access for a chunk of code [#137]
 
 - Declare ``setuptools`` runtime dependency [#93]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@
 0.9.0 (2021-01-14)
 ==================
 
+- Added ``..doctest-remote-data::`` directive to control remote data 
+  access for a chunk of code [#137]
+
 - Declare ``setuptools`` runtime dependency [#93]
 
 - Add ``SHOW_WARNINGS`` flag to show warnings. [#136]

--- a/README.rst
+++ b/README.rst
@@ -273,7 +273,17 @@ marked:
 
 The ``+REMOTE_DATA`` directive indicates that the marked statement should only
 be executed if the ``--remote-data`` option is given. By default, all
-statements marked with ``--remote-data`` will be skipped.
+statements marked with the remote data directive will be skipped.
+
+Whole code example blocks can also be marked to control access to data from the internet
+this way:
+
+.. code-block:: python
+
+    .. doctest-remote-data::
+
+        >>> import requests
+        >>> r = requests.get('https://www.astropy.org')
 
 .. _pytest-remotedata: https://github.com/astropy/pytest-remotedata
 __ pytest-remotedata_

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -324,6 +324,8 @@ def pytest_configure(config):
              installed.
 
            - ``.. doctest-skip-all``: Skip all subsequent doctests.
+
+           - ``.. doctest-remote-data``: Skip the next doctest chunk if --remote-data is not passed.
         """
 
         def parse(self, s, name=None):
@@ -381,6 +383,24 @@ def pytest_configure(config):
                                  sys.platform == 'win32')):
                             skip_next = True
                             continue
+
+                    if config.getoption('remote_data', 'none') != 'any':
+                        matches = [re.match(
+                            r'{}\s+doctest-remote-data\s*::(\s+.*)?'.format(comment_char),
+                            last_line) for last_line in last_lines]
+
+                        if len(matches) > 1:
+                            match = matches[0] or matches[1]
+                        else:
+                            match = matches[0]
+
+                        if match:
+                            marker = match.group(1)
+                            if (marker is None or
+                                    (marker.strip() == 'win32' and
+                                    sys.platform == 'win32')):
+                                skip_next = True
+                                continue
 
                     matches = [re.match(
                         r'{}\s+doctest-requires\s*::\s+(.*)'.format(comment_char),

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -359,8 +359,8 @@ def pytest_configure(config):
                     required = []
                     skip_next = False
                     lines = entry.strip().splitlines()
-                    if any([re.match(
-                            '{} doctest-skip-all'.format(comment_char), x.strip()) for x in lines]):
+                    if any(re.match(
+                            '{} doctest-skip-all'.format(comment_char), x.strip()) for x in lines):
                         skip_all = True
                         continue
 
@@ -388,9 +388,9 @@ def pytest_configure(config):
                             continue
 
                     if config.getoption('remote_data', 'none') != 'any':
-                        matches = [re.match(
+                        matches = (re.match(
                             r'{}\s+doctest-remote-data\s*::'.format(comment_char),
-                            last_line) for last_line in last_lines]
+                            last_line) for last_line in last_lines)
 
                         if any(matches):
                             skip_next = True

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -325,7 +325,7 @@ def pytest_configure(config):
 
            - ``.. doctest-skip-all``: Skip all subsequent doctests.
 
-           - ``.. doctest-remote-data``: Skip the next doctest chunk if --remote-data is not passed.
+           - ``.. doctest-remote-data::``: Skip the next doctest chunk if --remote-data is not passed.
         """
 
         def parse(self, s, name=None):
@@ -385,6 +385,7 @@ def pytest_configure(config):
                             continue
 
                     if config.getoption('remote_data', 'none') != 'any':
+                        print(config.getoption('remote_data', 'none') != 'any')
                         matches = [re.match(
                             r'{}\s+doctest-remote-data\s*::(\s+.*)?'.format(comment_char),
                             last_line) for last_line in last_lines]

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -392,12 +392,7 @@ def pytest_configure(config):
                             r'{}\s+doctest-remote-data\s*::'.format(comment_char),
                             last_line) for last_line in last_lines]
 
-                        if len(matches) > 1:
-                            match = matches[0] or matches[1]
-                        else:
-                            match = matches[0]
-
-                        if match:
+                        if any(matches):
                             skip_next = True
                             continue
 

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -90,9 +90,9 @@ def pytest_addoption(parser):
 
     parser.addoption("--text-file-format", action="store",
                      help=(
-                        "Text file format for narrative documentation. "
-                        "Options accepted are 'txt', 'tex', and 'rst'. "
-                        "This is no longer recommended, use --doctest-glob instead."
+                         "Text file format for narrative documentation. "
+                         "Options accepted are 'txt', 'tex', and 'rst'. "
+                         "This is no longer recommended, use --doctest-glob instead."
                      ))
 
     # Defaults to `atol` parameter from `numpy.allclose`.
@@ -140,8 +140,8 @@ def pytest_addoption(parser):
                   default=[])
 
     parser.addini("doctest_subpackage_requires",
-                  "A list of paths to skip if requirements are not satisfied. Each item in the list "
-                  "should have the syntax path=req1;req2",
+                  "A list of paths to skip if requirements are not satisfied."
+                  "Each item in the list should have the syntax path=req1;req2",
                   type='linelist',
                   default=[])
 
@@ -157,7 +157,8 @@ def get_optionflags(parent):
 def pytest_configure(config):
     doctest_plugin = config.pluginmanager.getplugin('doctest')
     run_regular_doctest = config.option.doctestmodules and not config.option.doctest_plus
-    use_doctest_plus = config.getini('doctest_plus') or config.option.doctest_plus or config.option.doctest_only
+    use_doctest_plus = config.getini(
+        'doctest_plus') or config.option.doctest_plus or config.option.doctest_only
     if doctest_plugin is None or run_regular_doctest or not use_doctest_plus:
         return
 
@@ -325,7 +326,8 @@ def pytest_configure(config):
 
            - ``.. doctest-skip-all``: Skip all subsequent doctests.
 
-           - ``.. doctest-remote-data::``: Skip the next doctest chunk if --remote-data is not passed.
+           - ``.. doctest-remote-data::``: Skip the next doctest chunk if
+             --remote-data is not passed.
         """
 
         def parse(self, s, name=None):
@@ -357,7 +359,8 @@ def pytest_configure(config):
                     required = []
                     skip_next = False
                     lines = entry.strip().splitlines()
-                    if any([re.match('{} doctest-skip-all'.format(comment_char), x.strip()) for x in lines]):
+                    if any([re.match(
+                            '{} doctest-skip-all'.format(comment_char), x.strip()) for x in lines]):
                         skip_all = True
                         continue
 
@@ -385,9 +388,8 @@ def pytest_configure(config):
                             continue
 
                     if config.getoption('remote_data', 'none') != 'any':
-                        print(config.getoption('remote_data', 'none') != 'any')
                         matches = [re.match(
-                            r'{}\s+doctest-remote-data\s*::(\s+.*)?'.format(comment_char),
+                            r'{}\s+doctest-remote-data\s*::'.format(comment_char),
                             last_line) for last_line in last_lines]
 
                         if len(matches) > 1:
@@ -396,12 +398,8 @@ def pytest_configure(config):
                             match = matches[0]
 
                         if match:
-                            marker = match.group(1)
-                            if (marker is None or
-                                    (marker.strip() == 'win32' and
-                                    sys.platform == 'win32')):
-                                skip_next = True
-                                continue
+                            skip_next = True
+                            continue
 
                     matches = [re.match(
                         r'{}\s+doctest-requires\s*::\s+(.*)'.format(comment_char),

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,10 @@ install_requires =
     setuptools>=30.3.0
     packaging>=17.0
 
+[options.extras_require]
+test = 
+    pytest-remotedata>=0.3.2
+
 [options.entry_points]
 pytest11 =
     pytest_doctestplus = pytest_doctestplus.plugin

--- a/tests/docs/skip_some.rst
+++ b/tests/docs/skip_some.rst
@@ -80,3 +80,77 @@ Code in doctest should run only if version condition is satisfied:
 .. doctest-requires:: pytest>=1.0 pytest>=2.0
 
     >>> import pytest
+
+
+Remote data block code sandwiched in block codes
+================================================
+
+This code block should work just fine::
+
+    >>> 1 + 1
+    2
+
+This should be skipped when remote data is not requested
+otherwise the test should fail::
+
+.. doctest-remote-data::
+
+    >>> 1 + 3
+    2
+
+This code block should work just fine::
+
+    >>> 1 + 1
+    2
+
+
+Remote data followed by plain block code
+========================================
+
+This one should be skipped when remote data is not requested
+otherwise the test should fail::
+
+.. doctest-remote-data::
+
+    >>> 1 + 3
+    2
+
+This code block should work just fine::
+
+    >>> 1 + 1
+    2
+
+
+Several blocks of Remote data
+=============================
+
+The three block codes should be skipped when remote data
+is not requested otherwise the tests should fail:
+
+.. doctest-remote-data::
+
+    >>> 1 + 3
+    2
+
+.. doctest-remote-data::
+
+    >>> 1 + 4
+    2
+
+.. doctest-remote-data::
+
+    >>> 1 + 5
+    2
+
+composite directive with remote data
+====================================
+
+This should be skipped otherwise the test should fail::
+
+.. doctest-remote-data::
+
+    >>> 1 + 1
+    3
+    >>> import warnings
+    >>> warnings.warn('A warning occurred', UserWarning)  # doctest: +IGNORE_WARNINGS
+    

--- a/tests/docs/skip_some.rst
+++ b/tests/docs/skip_some.rst
@@ -51,7 +51,7 @@ available:
 
 .. doctest-requires:: sys
 
-    >>> import sys 
+    >>> import sys
 
 Bad Imports
 ===========
@@ -80,77 +80,3 @@ Code in doctest should run only if version condition is satisfied:
 .. doctest-requires:: pytest>=1.0 pytest>=2.0
 
     >>> import pytest
-
-
-Remote data block code sandwiched in block codes
-================================================
-
-This code block should work just fine::
-
-    >>> 1 + 1
-    2
-
-This should be skipped when remote data is not requested
-otherwise the test should fail::
-
-.. doctest-remote-data::
-
-    >>> 1 + 3
-    2
-
-This code block should work just fine::
-
-    >>> 1 + 1
-    2
-
-
-Remote data followed by plain block code
-========================================
-
-This one should be skipped when remote data is not requested
-otherwise the test should fail::
-
-.. doctest-remote-data::
-
-    >>> 1 + 3
-    2
-
-This code block should work just fine::
-
-    >>> 1 + 1
-    2
-
-
-Several blocks of Remote data
-=============================
-
-The three block codes should be skipped when remote data
-is not requested otherwise the tests should fail:
-
-.. doctest-remote-data::
-
-    >>> 1 + 3
-    2
-
-.. doctest-remote-data::
-
-    >>> 1 + 4
-    2
-
-.. doctest-remote-data::
-
-    >>> 1 + 5
-    2
-
-composite directive with remote data
-====================================
-
-This should be skipped otherwise the test should fail::
-
-.. doctest-remote-data::
-
-    >>> 1 + 1
-    3
-    >>> import warnings
-    >>> warnings.warn('A warning occurred', UserWarning)  # doctest: +IGNORE_WARNINGS
-    

--- a/tests/docs/skip_some_remote_data.rst
+++ b/tests/docs/skip_some_remote_data.rst
@@ -1,0 +1,78 @@
+Some test cases for remote data
+*******************************
+
+We only run tests on this file when ``remote-data`` is not opted in as most
+of the code examples below should fail if not skipped.
+
+
+Remote data block code sandwiched in block codes
+================================================
+
+This code block should work just fine::
+
+    >>> 1 + 1
+    2
+
+This should be skipped when remote data is not requested
+otherwise the test should fail::
+
+.. doctest-remote-data::
+
+    >>> 1 + 3
+    2
+
+This code block should work just fine::
+
+    >>> 1 + 1
+    2
+
+
+Remote data followed by plain block code
+========================================
+
+This one should be skipped when remote data is not requested
+otherwise the test should fail::
+
+.. doctest-remote-data::
+
+    >>> 1 + 3
+    2
+
+This code block should work just fine::
+
+    >>> 1 + 1
+    2
+
+
+Several blocks of Remote data
+=============================
+
+The three block codes should be skipped when remote data
+is not requested otherwise the tests should fail:
+
+.. doctest-remote-data::
+
+    >>> 1 + 3
+    2
+
+.. doctest-remote-data::
+
+    >>> 1 + 4
+    2
+
+.. doctest-remote-data::
+
+    >>> 1 + 5
+    2
+
+Composite directive with remote data
+====================================
+
+This should be skipped otherwise the test should fail::
+
+.. doctest-remote-data::
+
+    >>> 1 + 1
+    3
+    >>> import warnings
+    >>> warnings.warn('A warning occurred', UserWarning)  # doctest: +IGNORE_WARNINGS

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -808,7 +808,7 @@ def test_remote_data_off(testdir):
     p = testdir.makefile(
         '.rst',
         """
-        # This test should fail, but we skip it, thus the test should be skipped.
+        # This test should be skipped when remote data is not requested.
         .. doctest-remote-data::
 
             >>> from contextlib import closing
@@ -830,8 +830,7 @@ def test_remote_data_float_cmp(testdir):
     p = testdir.makefile(
         '.rst',
         """
-        #This test is skipped when remote data is not requested, and should
-        #fails when remote data is requested
+        #This test is skipped when remote data is not requested
         .. doctest-remote-data::
 
             >>> x = 1/3.
@@ -898,7 +897,8 @@ def test_remote_data_requires(testdir):
     p = testdir.makefile(
         '.rst',
         """
-        #This test should be skipped even if remote data is requested because
+        #This test should be skipped when remote data is not requested.
+        #It should also be skipped instead of failing when remote data is requested because
         #the module required does not exist
         .. doctest-remote-data::
         .. doctest-requires:: does-not-exist

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -433,7 +433,7 @@ def test_ignore_warnings_rst(testdir):
     # First check that we get a warning if we don't add the IGNORE_WARNINGS
     # directive
     p = testdir.makefile(".rst",
-        """
+                         """
         ::
             >>> import warnings
             >>> warnings.warn('A warning occurred', UserWarning)
@@ -444,7 +444,7 @@ def test_ignore_warnings_rst(testdir):
 
     # Now try with the IGNORE_WARNINGS directive
     p = testdir.makefile(".rst",
-        """
+                         """
         ::
             >>> import warnings
             >>> warnings.warn('A warning occurred', UserWarning)  # doctest: +IGNORE_WARNINGS
@@ -486,7 +486,7 @@ def test_show_warnings_module(testdir):
 def test_show_warnings_rst(testdir):
 
     p = testdir.makefile(".rst",
-        """
+                         """
         ::
             >>> import warnings
             >>> warnings.warn('A warning occurred', UserWarning)  # doctest: +SHOW_WARNINGS
@@ -498,7 +498,7 @@ def test_show_warnings_rst(testdir):
 
     # Make sure it fails if warning message is missing
     p = testdir.makefile(".rst",
-        """
+                         """
         ::
             >>> import warnings
             >>> warnings.warn('A warning occurred', UserWarning)  # doctest: +SHOW_WARNINGS
@@ -509,7 +509,7 @@ def test_show_warnings_rst(testdir):
 
     # Make sure it fails if warning message is missing
     p = testdir.makefile(".rst",
-        """
+                         """
         ::
             >>> import warnings
             >>> warnings.warn('A warning occurred', UserWarning)  # doctest: +SHOW_WARNINGS
@@ -775,3 +775,34 @@ def test_doctest_skip(testdir):
         """
     )
     testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(skipped=1)
+
+
+def test_remote_data(testdir):
+    testdir.makeini(
+        """
+        [pytest]
+        doctestplus = enabled
+    """)
+
+    # should be ignored
+    p = testdir.makefile(
+        '.rst',
+        """
+        .. doctest-remote-data::
+            >>> 1 + 1
+            2
+        """
+    )
+    testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(skipped=1)
+
+    # should run
+    p = testdir.makefile(
+        '.rst',
+        """
+        .. doctest-remote-data::
+            >>> 1 + 1
+            2
+        """
+    )
+    testdir.inline_run(p, '--doctest-plus', '--doctest-rst',
+                       '--remote-data').assertoutcome(passed=1)

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -777,28 +777,8 @@ def test_doctest_skip(testdir):
     testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(skipped=1)
 
 
-def test_remote_data_on(testdir):
-    testdir.makeini(
-        """
-        [pytest]
-        doctestplus = enabled
-    """)
-
-    p = testdir.makefile(
-        '.rst',
-        """
-        # This test should pass
-        .. doctest-remote-data::
-
-            >>> 1 + 1
-            2
-        """
-    )
-    testdir.inline_run(p, '--doctest-plus', '--doctest-rst',
-                       '--remote-data').assertoutcome(passed=1)
-
-
-def test_remote_data_off(testdir):
+# We repeat all testst including remote data with and without it opted in
+def test_remote_data_url(testdir):
     testdir.makeini(
         """
         [pytest]
@@ -817,6 +797,7 @@ def test_remote_data_off(testdir):
             ...     remote.read()    # doctest: +IGNORE_OUTPUT
         """
     )
+    testdir.inline_run(p, '--doctest-plus', '--doctest-rst', '--remote-data').assertoutcome(passed=1)
     testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(skipped=1)
 
 
@@ -838,6 +819,7 @@ def test_remote_data_float_cmp(testdir):
             0.333333
         """
     )
+    testdir.inline_run(p, '--doctest-plus', '--doctest-rst', '--remote-data').assertoutcome(passed=1)
     testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(skipped=1)
 
 
@@ -861,6 +843,7 @@ def test_remote_data_ignore_whitespace(testdir):
             foo
         """
     )
+    testdir.inline_run(p, '--doctest-plus', '--doctest-rst', '--remote-data').assertoutcome(passed=1)
     testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(skipped=1)
 
 
@@ -875,8 +858,8 @@ def test_remote_data_ellipsis(testdir):
     p = testdir.makefile(
         '.rst',
         """
-        #This test should be skipped when remote data is not requested, and should
-        #pass when remote data is requested
+        # This test should be skipped when remote data is not requested, and should
+        # pass when remote data is requested
         .. doctest-remote-data::
 
             >>> a = "freedom at last"
@@ -884,6 +867,7 @@ def test_remote_data_ellipsis(testdir):
             freedom ...
         """
     )
+    testdir.inline_run(p, '--doctest-plus', '--doctest-rst', '--remote-data').assertoutcome(passed=1)
     testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(skipped=1)
 
 
@@ -897,9 +881,9 @@ def test_remote_data_requires(testdir):
     p = testdir.makefile(
         '.rst',
         """
-        #This test should be skipped when remote data is not requested.
-        #It should also be skipped instead of failing when remote data is requested because
-        #the module required does not exist
+        # This test should be skipped when remote data is not requested.
+        # It should also be skipped instead of failing when remote data is requested because
+        # the module required does not exist
         .. doctest-remote-data::
         .. doctest-requires:: does-not-exist
 
@@ -907,6 +891,7 @@ def test_remote_data_requires(testdir):
             3
         """
     )
+    testdir.inline_run(p, '--doctest-plus', '--doctest-rst', '--remote-data').assertoutcome(skipped=1)
     testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(skipped=1)
 
 
@@ -920,11 +905,12 @@ def test_remote_data_ignore_warnings(testdir):
     p = testdir.makefile(
         '.rst',
         """
-        #This test should be skipped if remote data is not requested.
+        # This test should be skipped if remote data is not requested.
         .. doctest-remote-data::
 
             >>> import warnings
             >>> warnings.warn('A warning occurred', UserWarning)  # doctest: +IGNORE_WARNINGS
         """
     )
+    testdir.inline_run(p, '--doctest-plus', '--doctest-rst', '--remote-data').assertoutcome(passed=1)
     testdir.inline_run(p, '--doctest-plus', '--doctest-rst').assertoutcome(skipped=1)

--- a/tox.ini
+++ b/tox.ini
@@ -26,10 +26,13 @@ extras =
 
 commands =
     pip freeze
+    # Ignore directly running tests in `skip_some.rst` with remote-data as there are some artifical failures included in there.
+    pytest {toxinidir}/tests --ignore={toxinidir}/tests/docs/skip_some.rst --doctest-plus --doctest-rst --remote-data {posargs}
     pytest {toxinidir}/tests {posargs}
     pytest {toxinidir}/tests --doctest-plus {posargs}
     pytest {toxinidir}/tests --doctest-plus --doctest-rst {posargs}
     pytest {toxinidir}/tests --doctest-plus --doctest-rst --text-file-format=tex {posargs}
+
 
 [testenv:codestyle]
 changedir =

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,9 @@ extras =
 
 commands =
     pip freeze
-    # Ignore directly running tests in `skip_some.rst` with remote-data as there are some artifical failures included in there.
-    pytest {toxinidir}/tests --ignore={toxinidir}/tests/docs/skip_some.rst --doctest-plus --doctest-rst --remote-data {posargs}
+    # Ignore directly running tests in ``skip_some_remote_data.rst`` with
+    # ``remote-data`` as there are some artifical failures included in there.
+    pytest {toxinidir}/tests --ignore={toxinidir}/tests/docs/skip_some_remote_data.rst --doctest-plus --doctest-rst --remote-data {posargs}
     pytest {toxinidir}/tests {posargs}
     pytest {toxinidir}/tests --doctest-plus {posargs}
     pytest {toxinidir}/tests --doctest-plus --doctest-rst {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,9 @@ deps =
     pytest62: pytest==6.2.*
     pytestdev: git+https://github.com/pytest-dev/pytest#egg=pytest
 
+extras =
+    test
+
 commands =
     pip freeze
     pytest {toxinidir}/tests {posargs}


### PR DESCRIPTION
This is my attempt of resolving the issue of adding directive supporting the use of remote data in doctests. 
The issue can be found here https://github.com/astropy/pytest-doctestplus/issues/2 

EDIT: Fix #2 

EDIT: Re-posted notes from the author below.

* A fourth directive `.. doctest-remote-data::`   that skips the next doctest chunk if `--remote-data` is not passed as an argument to the pytest command is included
* If `--remote-data` option was not passed then check the chunk of strings provided by the result of `doctest.DocTestParser.parse` for the new directives using regex
* If the new directive was matched, then skip the test