### PR TITLE
MNT: Use --strict in twine check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,8 +26,9 @@ jobs:
     - name: List result
       run: ls -l dist
 
+    # Only twine>=3.3 has --strict
     - name: Check long_description
-      run: python -m twine check dist/*
+      run: python -m twine check --strict dist/*
 
     - name: Test package
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: 3.8
 
     - name: Install python-build and twine
-      run: python -m pip install build twine
+      run: python -m pip install build twine>=3.3
 
     - name: Build package
       run: python -m build --sdist --wheel .
@@ -26,7 +26,6 @@ jobs:
     - name: List result
       run: ls -l dist
 
-    # Only twine>=3.3 has --strict
     - name: Check long_description
       run: python -m twine check --strict dist/*
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: 3.8
 
     - name: Install python-build and twine
-      run: python -m pip install build twine>=3.3
+      run: python -m pip install build "twine>=3.3"
 
     - name: Build package
       run: python -m build --sdist --wheel .


### PR DESCRIPTION
Follow up of https://github.com/pypa/twine/pull/715#issuecomment-750851291

With `--strict`, `twine check` will fail if there are warnings, preventing a release until they are fixed.