### PR TITLE
Fixed logic for IGNORE_WARNINGS/SHOW_WARNINGS for --remote-data=any

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 0.10.0 (unreleased)
 ===================
 
+- Fixed a bug where the command-line option ``--remote-data=any`` (associated
+  with the ``pytest-remotedata`` plugin) would cause ``IGNORE_WARNINGS`` and
+  ``SHOW_WARNINGS`` options to be ignored in module docstrings. [#152]
+
 - Fix wrong behavior with ``IGNORE_WARNINGS`` and ``SHOW_WARNINGS`` that could
   make a block to pass instead of being skipped. [#148]
 


### PR DESCRIPTION
This PR fixes a bug where the handling of `IGNORE_WARNINGS`/`SHOW_WARNINGS` flags in module docstrings is entirely skipped over if `--remote-data=any` is specified (for concurrent use of the `pytest-remotedata` plugin).