### PR TITLE
Setup updates, remove Python 3.6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,16 @@
 name: Release
 
 on:
+  pull_request:
   push:
+    tags:
+      - '*'
 
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-latest
-    if: github.repository == 'astropy/pytest-doctestplus'
+    if: (github.repository == 'astropy/pytest-doctestplus' && (github.event_name == 'tags' || contains(github.event.pull_request.labels.*.name, 'Build wheels')))
 
     steps:
     - uses: actions/checkout@v2
@@ -37,7 +40,7 @@ jobs:
         testenv/bin/pytest pytest-doctestplus/tests --doctest-plus --doctest-rst
 
     - name: Publish distribution 📦 to PyPI
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,11 +18,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python-version: 3.6
-            toxenv: py36-test-pytest46
+            python-version: 3.7
+            toxenv: py37-test-pytest46
           - os: windows-latest
-            python-version: 3.6
-            toxenv: py36-test-pytest50
+            python-version: 3.7
+            toxenv: py37-test-pytest50
           - os: macos-latest
             python-version: 3.7
             toxenv: py37-test-pytest51

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.10.0 (unreleased)
 ===================
 
+- Drop support for ``python`` 3.6. [#159]
+
 - Fixed a bug where the command-line option ``--remote-data=any`` (associated
   with the ``pytest-remotedata`` plugin) would cause ``IGNORE_WARNINGS`` and
   ``SHOW_WARNINGS`` options to be ignored in module docstrings. [#152]

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,9 +12,9 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Software Development :: Testing
     Topic :: Utilities
@@ -27,7 +27,7 @@ keywords = doctest, rst, pytest, py.test
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires =
     setuptools_scm
 install_requires =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39}-test
+    py{37,38,39}-test
     codestyle
 requires =
     setuptools >= 30.3.0


### PR DESCRIPTION
Small updates while using doctestplus as an example for sphinx-astropy.