### PR TITLE
Adding the doctest-remote-data directive to sphinx

### DIFF
--- a/pytest_doctestplus/sphinx/doctestplus.py
+++ b/pytest_doctestplus/sphinx/doctestplus.py
@@ -46,6 +46,7 @@ def setup(app):
     app.add_directive('doctest-skip', DoctestSkipDirective)
     app.add_directive('doctest-skip-all', DoctestSkipDirective)
     app.add_directive('doctest', DoctestSkipDirective, override=True)
+    app.add_directive('doctest-remote-data', DoctestSkipDirective)
     # Code blocks that use this directive will not appear in the generated
     # documentation. This is intended to hide boilerplate code that is only
     # useful for testing documentation using doctest, but does not actually


### PR DESCRIPTION
This one is required to fix #161 via https://github.com/astropy/sphinx-astropy/pull/45

A changelog entry will be also required, and am happy to tag a new release to get rid of those fires. The only question is that should it be 0.9.1 or a new 0.10.0?