### PR TITLE
Adding basic sphinx config to be able to sphinx-build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,8 +36,9 @@ install_requires =
     packaging>=17.0
 
 [options.extras_require]
-test = 
+test =
     pytest-remotedata>=0.3.2
+    sphinx
 
 [options.entry_points]
 pytest11 =

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -50,4 +50,4 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -1,0 +1,52 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'pytest-doctestplus'
+copyright = '2021, Astropy Infrastructure Team'
+author = 'Astropy Infrastructure Team'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -28,6 +28,7 @@ author = 'Astropy Infrastructure Team'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'pytest_doctestplus.sphinx.doctestplus'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/tests/docs/skip_all.rst
+++ b/tests/docs/skip_all.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. doctest-skip-all
 
 Some Bad Test Cases

--- a/tests/docs/skip_some.rst
+++ b/tests/docs/skip_some.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Some Good Test Cases
 ********************
 

--- a/tests/docs/skip_some_remote_data.rst
+++ b/tests/docs/skip_some_remote_data.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Some test cases for remote data
 *******************************
 

--- a/tests/index.rst
+++ b/tests/index.rst
@@ -1,0 +1,20 @@
+.. pytest-doctestplus documentation master file, created by
+   sphinx-quickstart on Mon Jul 19 12:06:17 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to pytest-doctestplus's documentation!
+==============================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/tests/make.bat
+++ b/tests/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands =
     pytest {toxinidir}/tests --doctest-plus {posargs}
     pytest {toxinidir}/tests --doctest-plus --doctest-rst {posargs}
     pytest {toxinidir}/tests --doctest-plus --doctest-rst --text-file-format=tex {posargs}
-    sphinx-build tests tests/_build/html -W
+    sphinx-build {toxinidir}/tests {toxinidir}/tests/_build/html -W
 
 [testenv:codestyle]
 changedir =

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ commands =
     pytest {toxinidir}/tests --doctest-plus {posargs}
     pytest {toxinidir}/tests --doctest-plus --doctest-rst {posargs}
     pytest {toxinidir}/tests --doctest-plus --doctest-rst --text-file-format=tex {posargs}
-
+    sphinx-build tests tests/_build/html -W
 
 [testenv:codestyle]
 changedir =


### PR DESCRIPTION
This is to be able to run the simplest `sphinx-build tests tests/_build/html` job to render the docs.

We only need this to be able to check whether the directives indeed work, not to create a narrative docs, so probably a CI job is enough, no need to drag RTD into the picture.