### PR TITLE
MNT: Stop using distutils

### DIFF
--- a/pytest_doctestplus/sphinx/doctestplus.py
+++ b/pytest_doctestplus/sphinx/doctestplus.py
@@ -19,7 +19,7 @@ class DoctestSkipDirective(Directive):
 
     def run(self):
         # Check if there is any valid argument, and skip it. Currently only
-        # 'win32' is supported in astropy.tests.pytest_plugins.
+        # 'win32' is supported.
         if re.match('win32', self.content[0]):
             self.content = self.content[2:]
         code = '\n'.join(self.content)

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -1,5 +1,5 @@
 import os
-from distutils.version import LooseVersion
+from packaging.version import Version
 from textwrap import dedent
 
 import pytest
@@ -651,7 +651,7 @@ def test_ignore_option(testdir):
     ).assertoutcome(passed=2)
 
 
-if LooseVersion('4.3.0') <= LooseVersion(pytest.__version__):
+if Version('4.3.0') <= Version(pytest.__version__):
     def test_ignore_glob_option(testdir):
         testdir.makepyfile(foo="""
             def f():


### PR DESCRIPTION
`distutils` is deprecated. Also remove outdated comment.