### PR TITLE
Use windows-2019 for GitHub Actions jobs

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -20,7 +20,7 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.7
             toxenv: py37-test-pytest46
-          - os: windows-latest
+          - os: windows-2019
             python-version: 3.7
             toxenv: py37-test-pytest50
           - os: macos-latest
@@ -29,7 +29,7 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.7
             toxenv: py37-test-pytest52
-          - os: windows-latest
+          - os: windows-2019
             python-version: 3.8
             toxenv: py38-test-pytest53
           - os: ubuntu-latest


### PR DESCRIPTION
The windows-latest GitHub Actions virtual environment just switched from windows-2019 to windows-2022. The windows-2022 virtual environment cannot build Python C extensions (see actions/virtual-environments#5141). As a temporary workaround, switch to using windows-2019.

Fixes #177.