### PR TITLE
Revert "Use windows-2019 for GitHub Actions jobs"

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -20,7 +20,7 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.7
             toxenv: py37-test-pytest46
-          - os: windows-2019
+          - os: windows-latest
             python-version: 3.7
             toxenv: py37-test-pytest50
           - os: macos-latest
@@ -29,7 +29,7 @@ jobs:
           - os: ubuntu-latest
             python-version: 3.7
             toxenv: py37-test-pytest52
-          - os: windows-2019
+          - os: windows-latest
             python-version: 3.8
             toxenv: py38-test-pytest53
           - os: ubuntu-latest


### PR DESCRIPTION
Reverts astropy/pytest-doctestplus#178.

This might be fixed now...