### PR TITLE
Allow float comparison in dicts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.12.1 (unreleased)
 ===================
 
+- Allow floating point comparison in Python dictionary. [#186]
+
 0.12.0 (2022-02-25)
 ===================
 

--- a/README.rst
+++ b/README.rst
@@ -144,6 +144,11 @@ To address this issue, the ``pytest-doctestplus`` plugin provides support for a
   >>> 1.0 / 3.0  # doctest: +FLOAT_CMP
   0.333333333333333311
 
+.. code-block:: python
+
+  >>> {'a': 1 / 3., 'b': 2 / 3.}  # doctest: +FLOAT_CMP
+  {'a': 0.333333, 'b': 0.666666}
+
 When this flag is used, the expected and actual outputs are both parsed to find
 any floating point values in the strings.  Those are then converted to actual
 Python `float` objects and compared numerically.  This means that small

--- a/pytest_doctestplus/output_checker.py
+++ b/pytest_doctestplus/output_checker.py
@@ -70,7 +70,7 @@ class OutputChecker(doctest.OutputChecker):
         want_floats = got_floats + r'(\.{3})?'
 
         front_sep = r'\s|[*+-,<=(\[]'
-        back_sep = front_sep + r'|[>j)\]]'
+        back_sep = front_sep + r'|[>j)\]}]'
 
         fbeg = r'^{}(?={}|$)'.format(got_floats, back_sep)
         fmidend = r'(?<={}){}(?={}|$)'.format(front_sep, got_floats, back_sep)

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -112,6 +112,29 @@ def test_float_cmp_list(testdir):
     reprec.assertoutcome(failed=0, passed=1)
 
 
+def test_float_cmp_dict(testdir):
+    testdir.makeini(
+        """
+        [pytest]
+        doctest_optionflags = ELLIPSIS
+        doctestplus = enabled
+    """
+    )
+    p = testdir.makepyfile(
+        """
+        def g():
+            '''
+            >>> x = {'a': 1/3., 'b': 2/3.}
+            >>> x    # doctest: +FLOAT_CMP
+            {'a': 0.333333, 'b': 0.666666}
+            '''
+            pass
+    """
+    )
+    reprec = testdir.inline_run(p, "--doctest-plus")
+    reprec.assertoutcome(failed=0, passed=1)
+
+
 def test_float_cmp_global(testdir):
     testdir.makeini("""
         [pytest]


### PR DESCRIPTION
Before this PR, floating numbers in arrays are compared as floating numbers, but floating numbers in dicts are not, because they end on "}". This PR simply adds "}" to the regexp that determines what can be at the end of a floating number to allows for doctests like

            >>> x = {'a': 1/3., 'b': 2/3.}
            >>> x    # doctest: +FLOAT_CMP
            {'a': 0.333333, 'b': 0.666666}

which failed before this PR.