### PR TITLE
Replace `tmpdir` test fixture with `tmp_path`

### DIFF
--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -731,7 +731,7 @@ def test_doctest_only(testdir, makepyfile, maketestfile, makerstfile):
     testdir.inline_run("--doctest-only", "--doctest-rst").assertoutcome(passed=3, failed=2)
 
 
-def test_doctest_float_replacement(tmpdir):
+def test_doctest_float_replacement(tmp_path):
     test1 = dedent("""
         This will demonstrate a doctest that fails due to a few extra decimal
         places::
@@ -748,17 +748,27 @@ def test_doctest_float_replacement(tmpdir):
             0.333333333333333311
     """)
 
-    test1_rst = tmpdir.join('test1.rst')
-    test2_rst = tmpdir.join('test2.rst')
-    test1_rst.write(test1)
-    test2_rst.write(test2)
+    test1_rst = tmp_path / "test1.rst"
+    test2_rst = tmp_path / "test2.rst"
+    test1_rst.write_text(test1)
+    test2_rst.write_text(test2)
 
     with pytest.raises(doctest.DocTestFailure):
-        doctest.testfile(str(test1_rst), module_relative=False,
-                         raise_on_error=True, verbose=False, encoding='utf-8')
+        doctest.testfile(
+            test1_rst,
+            module_relative=False,
+            raise_on_error=True,
+            verbose=False,
+            encoding="utf-8",
+        )
 
-    doctest.testfile(str(test2_rst), module_relative=False,
-                     raise_on_error=True, verbose=False, encoding='utf-8')
+    doctest.testfile(
+        test2_rst,
+        module_relative=False,
+        raise_on_error=True,
+        verbose=False,
+        encoding="utf-8",
+    )
 
 
 def test_doctest_subpackage_requires(testdir, caplog):


### PR DESCRIPTION
[`pytest` provides two fixtures for creating temporary directories](https://docs.pytest.org/en/stable/how-to/tmp_path.html): the recommended `tmp_path`, which uses `pathlib.Path` from the Python standard library, and the legacy `tmpdir`, which uses a third party library. The tests here now use `tmp_path` instead of `tmpdir`.

For the same reason the [`testdir`](https://docs.pytest.org/en/stable/reference/reference.html?highlight=testdir#testdir) fixture should be replaced with [`pytester`](https://docs.pytest.org/en/stable/reference/reference.html?highlight=testdir#pytester), but that would require the minimum supported `pytest` version to be 6.2.