### PR TITLE
DOC: Version check is supported in the doctest-requires directive since v0.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -288,6 +288,16 @@ conditionally skipped if a dependency is not available.
         >>> import asdf
         >>> asdf.open('file.asdf')
 
+Furthermore, if the code only runs for specific versions of the optional dependency,
+you can add a version check like this::
+
+.. code-block:: rst
+
+    .. doctest-requires:: asdf<3
+
+        >>> import asdf
+        >>> asdf.open('file.asdf')
+
 Finally, it is possible to skip collecting doctests in entire subpackages by
 using the ``doctest_subpackage_requires`` in the ``[tool:pytest]`` section of
 the package's ``setup.cfg`` file. The syntax for this option is a list of


### PR DESCRIPTION
Version check is supported in the `doctest-requires` directive since v0.5 (2019-11-15, #78) but I didn't know until I dug into the change log.

ref: https://github.com/astropy/astropy/pull/14797#discussion_r1189980217