### PR TITLE
MNT: Do not completely take over test collection ignore

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.12.2 (unreleased)
 ===================
 
+- Compatibility with pytest 7.4 w.r.t. norecursedirs handling. [#201]
+
 - Respect ``--doctest-continue-on-failure`` flag. [#197]
 
 - Report doctests raising skip exceptions as skipped. [#196]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.12.2 (unreleased)
 ===================
 
-- Compatibility with pytest 7.4 w.r.t. norecursedirs handling. [#201]
+- Compatibility with pytest 7.4 with respect to ``norecursedirs`` handling. [#201]
 
 - Respect ``--doctest-continue-on-failure`` flag. [#197]
 

--- a/pytest_doctestplus/plugin.py
+++ b/pytest_doctestplus/plugin.py
@@ -554,7 +554,7 @@ class DoctestPlus(object):
                     self._ignore_paths.append(path)
                     break
 
-        return False
+        # None = Let other plugins decide the outcome.
 
     def pytest_collect_file(self, path, parent):
         """Implements an enhanced version of the doctest module from py.test

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -1142,3 +1142,26 @@ def test_ufunc(testdir):
 
     result = testdir.inline_run(build_dir, '--doctest-plus', '--doctest-modules', '--doctest-ufunc')
     result.assertoutcome(passed=2, failed=0)
+
+
+def test_norecursedirs(pytester):
+    pytester.makeini(
+        """
+        [pytest]
+        norecursedirs = \"bad_dir\"
+        doctestplus = enabled
+    """
+    )
+    subdir = pytester.mkdir("bad_dir")
+    with open(subdir / "test_foobar.py", "w") as fout:
+        fout.write("""
+        def f():
+            '''
+            >>> x = 1/3.
+            >>> x
+            0.333333
+            '''
+            fail
+    """)
+    reprec = pytester.inline_run(pytester.path, "--doctest-plus")
+    reprec.assertoutcome(failed=0, passed=0)

--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -1144,17 +1144,17 @@ def test_ufunc(testdir):
     result.assertoutcome(passed=2, failed=0)
 
 
-def test_norecursedirs(pytester):
-    pytester.makeini(
+def test_norecursedirs(testdir):
+    testdir.makeini(
         """
         [pytest]
         norecursedirs = \"bad_dir\"
         doctestplus = enabled
     """
     )
-    subdir = pytester.mkdir("bad_dir")
-    with open(subdir / "test_foobar.py", "w") as fout:
-        fout.write("""
+    subdir = testdir.mkdir("bad_dir")
+    badfile = subdir.join("test_foobar.py")
+    badfile.write_text("""
         def f():
             '''
             >>> x = 1/3.
@@ -1162,6 +1162,6 @@ def test_norecursedirs(pytester):
             0.333333
             '''
             fail
-    """)
-    reprec = pytester.inline_run(pytester.path, "--doctest-plus")
+    """, "utf-8")
+    reprec = testdir.inline_run(str(testdir), "--doctest-plus")
     reprec.assertoutcome(failed=0, passed=0)


### PR DESCRIPTION
Main motivation is to fix compatibility with pytest 7.4.0.dev though theoretically this plugin should not completely take over the ignore part of test collection? See https://github.com/pytest-dev/pytest/pull/11082#issuecomment-1579954425 for more details. Affected issue:

* https://github.com/astropy/astropy/issues/14930

I am adding a test first to make sure it fails in pytest-dev before trying out the patch. ~I am also using `pytester` instead of `testdir`~, see #200 .