### PR TITLE
TST: Catch ResourceWarning under bad combo

### DIFF
--- a/tests/test_doctestplus.py
+++ b/tests/test_doctestplus.py
@@ -732,21 +732,19 @@ def test_ignore_option(testdir):
     testdir.makefile('.rst', foo='>>> 1+1\n2')
 
     testdir.inline_run('--doctest-plus').assertoutcome(passed=2)
-    testdir.inline_run('--doctest-plus', '--doctest-rst').assertoutcome(passed=3)
-    testdir.inline_run(
-        '--doctest-plus', '--doctest-rst', '--ignore', '.'
-    ).assertoutcome(passed=0)
     if os.name == "nt" and python_version() == "3.14.0" and not PYTEST_LT_8_5:
         with warnings.catch_warnings():
             # ResourceWarning unclosed file pytest.EXE --> PytestUnraisableExceptionWarning
             warnings.filterwarnings("ignore")
-            testdir.inline_run(
-                '--doctest-plus', '--doctest-rst', '--ignore', 'bar.py'
-            ).assertoutcome(passed=2)
+            testdir.inline_run('--doctest-plus', '--doctest-rst').assertoutcome(passed=3)
     else:
-        testdir.inline_run(
-            '--doctest-plus', '--doctest-rst', '--ignore', 'bar.py'
-        ).assertoutcome(passed=2)
+        testdir.inline_run('--doctest-plus', '--doctest-rst').assertoutcome(passed=3)
+    testdir.inline_run(
+        '--doctest-plus', '--doctest-rst', '--ignore', '.'
+    ).assertoutcome(passed=0)
+    testdir.inline_run(
+        '--doctest-plus', '--doctest-rst', '--ignore', 'bar.py'
+    ).assertoutcome(passed=2)
 
 
 def test_ignore_glob_option(testdir):


### PR DESCRIPTION
Close #305 

I think this is okay for now? Looks like the problem is somewhere in between Python 3.14 and pytest. Not sure how to debug. The conditions are specific enough that it won't accidentally ignore other stuff, I hope. Who knows, might magically fixed in Python 3.14.1 if it is Python. Or we can also open reminder issue to revisit in the future. What do you think?